### PR TITLE
Kgl host removal dev

### DIFF
--- a/tasks/task_read_clean.wdl
+++ b/tasks/task_read_clean.wdl
@@ -5,7 +5,7 @@ task ncbi_scrub_pe {
     File        read1
     File        read2
     String      samplename
-    String      docker = "ncbi/sra-human-scrubber:1.0.2021-04-19"
+    String      docker = "ncbi/sra-human-scrubber:1.0.2021-05-05"
 
   }
   String r1_filename = basename(read1)
@@ -25,7 +25,7 @@ task ncbi_scrub_pe {
     fi
 
     # dehost reads
-    /opt/scrubber/scripts/scrub.sh ${read1_unzip}
+    /opt/scrubber/scripts/scrub.sh -n ${read1_unzip} | awk -F" " '{print $1}' > FWD_SPOTS_REMOVED
 
     # gzip dehosted reads
     gzip ${read1_unzip}.clean -c > ~{samplename}_R1_dehosted.fastq.gz
@@ -41,10 +41,10 @@ task ncbi_scrub_pe {
     fi
 
     # dehost reads
-    /opt/scrubber/scripts/scrub.sh ${read2_unzip}
+    /opt/scrubber/scripts/scrub.sh -n ${read2_unzip} | awk -F" " '{print $1}' > REV_SPOTS_REMOVED
 
     # gzip dehosted reads
-    gzip ${read2_unzip}.clean -c > ~{samplename}_R2_dehosted.fastq.gz
+    gzip ${read2_unzip}.clean -c > ~{samplename}_R2_dehosted.fastq.gz 
 
 
   >>>
@@ -52,7 +52,10 @@ task ncbi_scrub_pe {
   output {
     File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
     File read2_dehosted = "~{samplename}_R2_dehosted.fastq.gz"
+    Int read1_human_spots_removed = read_int("FWD_SPOTS_REMOVED")
+    Int read2_human_spots_removed = read_int("REF_SPORTS_REMOVED")
     String ncbi_scrub_docker = docker
+
   }
 
   runtime {
@@ -68,7 +71,7 @@ task ncbi_scrub_se {
   input {
     File        read1
     String      samplename
-    String      docker = "ncbi/sra-human-scrubber:1.0.2021-04-19"
+    String      docker = "ncbi/sra-human-scrubber:1.0.2021-05-05"
 
   }
   String r1_filename = basename(read1)
@@ -87,7 +90,7 @@ task ncbi_scrub_se {
     fi
 
     # dehost reads
-    /opt/scrubber/scripts/scrub.sh ${read1_unzip}
+    /opt/scrubber/scripts/scrub.sh -n ${read1_unzip} | awk -F" " '{print $1}' > FWD_SPOTS_REMOVED
 
     # gzip dehosted reads
     gzip ${read1_unzip}.clean -c > ~{samplename}_R1_dehosted.fastq.gz
@@ -96,7 +99,9 @@ task ncbi_scrub_se {
 
   output {
     File       read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
+    Int read1_human_spots_removed = read_int("FWD_SPOTS_REMOVED")
     String     ncbi_scrub_docker    = docker
+
   }
 
   runtime {

--- a/tasks/task_read_clean.wdl
+++ b/tasks/task_read_clean.wdl
@@ -25,7 +25,7 @@ task ncbi_scrub_pe {
     fi
 
     # dehost reads
-    /opt/scrubber/scripts/scrub.sh -n ${read1_unzip} | awk -F" " '{print $1}' > FWD_SPOTS_REMOVED
+    /opt/scrubber/scripts/scrub.sh -n ${read1_unzip} |& tail -n1 | awk -F" " '{print $1}' > FWD_SPOTS_REMOVED
 
     # gzip dehosted reads
     gzip ${read1_unzip}.clean -c > ~{samplename}_R1_dehosted.fastq.gz
@@ -41,7 +41,7 @@ task ncbi_scrub_pe {
     fi
 
     # dehost reads
-    /opt/scrubber/scripts/scrub.sh -n ${read2_unzip} | awk -F" " '{print $1}' > REV_SPOTS_REMOVED
+    /opt/scrubber/scripts/scrub.sh -n ${read2_unzip} |& tail -n1 | awk -F" " '{print $1}' > REV_SPOTS_REMOVED
 
     # gzip dehosted reads
     gzip ${read2_unzip}.clean -c > ~{samplename}_R2_dehosted.fastq.gz 
@@ -53,7 +53,7 @@ task ncbi_scrub_pe {
     File read1_dehosted = "~{samplename}_R1_dehosted.fastq.gz"
     File read2_dehosted = "~{samplename}_R2_dehosted.fastq.gz"
     Int read1_human_spots_removed = read_int("FWD_SPOTS_REMOVED")
-    Int read2_human_spots_removed = read_int("REF_SPORTS_REMOVED")
+    Int read2_human_spots_removed = read_int("REV_SPOTS_REMOVED")
     String ncbi_scrub_docker = docker
 
   }
@@ -90,7 +90,7 @@ task ncbi_scrub_se {
     fi
 
     # dehost reads
-    /opt/scrubber/scripts/scrub.sh -n ${read1_unzip} | awk -F" " '{print $1}' > FWD_SPOTS_REMOVED
+    /opt/scrubber/scripts/scrub.sh -n ${read1_unzip} |& tail -n1 | awk -F" " '{print $1}' > FWD_SPOTS_REMOVED
 
     # gzip dehosted reads
     gzip ${read1_unzip}.clean -c > ~{samplename}_R1_dehosted.fastq.gz

--- a/tasks/task_read_clean.wdl
+++ b/tasks/task_read_clean.wdl
@@ -173,7 +173,7 @@ task trimmomatic {
     File        read2
     String      samplename
     String      docker="staphb/trimmomatic:0.39"
-    Int?        trimmomatic_minlen = 15
+    Int?        trimmomatic_minlen = 25
     Int?        trimmomatic_window_size=4
     Int?        trimmomatic_quality_trim_score=30
     Int?    threads = 4

--- a/tasks/task_read_clean.wdl
+++ b/tasks/task_read_clean.wdl
@@ -173,7 +173,7 @@ task trimmomatic {
     File        read2
     String      samplename
     String      docker="staphb/trimmomatic:0.39"
-    Int?        trimmomatic_minlen = 25
+    Int?        trimmomatic_minlen = 75
     Int?        trimmomatic_window_size=4
     Int?        trimmomatic_quality_trim_score=30
     Int?    threads = 4

--- a/tasks/task_read_clean.wdl
+++ b/tasks/task_read_clean.wdl
@@ -61,7 +61,7 @@ task ncbi_scrub_pe {
   runtime {
       docker:       "~{docker}"
       memory:       "8 GB"
-      cpu:          2
+      cpu:          4
       disks:        "local-disk 100 SSD"
       preemptible:  0
   }
@@ -107,7 +107,7 @@ task ncbi_scrub_se {
   runtime {
       docker:       "~{docker}"
       memory:       "8 GB"
-      cpu:          2
+      cpu:          4
       disks:        "local-disk 100 SSD"
       preemptible:  0
   }

--- a/workflows/wf_ncbi_scrub_pe.wdl
+++ b/workflows/wf_ncbi_scrub_pe.wdl
@@ -26,6 +26,8 @@ workflow dehost_pe {
 	output {
 			File	read1_dehosted	=	ncbi_scrub_pe.read1_dehosted
 			File 	read2_dehosted	=	ncbi_scrub_pe.read2_dehosted
+			Int		read1_human_sports_removed = ncbi_scrub_pe.read1_human_spots_removed
+			Int 	read2_human_sports_removed = ncbi_scrub_pe.read2_human_spots_removed
 			String	ncbi_scrub_docker	=	ncbi_scrub_pe.ncbi_scrub_docker
 
 			Float	kraken_human_dehosted	=	kraken2.percent_human

--- a/workflows/wf_ncbi_scrub_se.wdl
+++ b/workflows/wf_ncbi_scrub_se.wdl
@@ -22,6 +22,7 @@ workflow dehost_se {
 	output {
 			File	reads_dehosted	=	ncbi_scrub_se.read1_dehosted
 			String	ncbi_scrub_docker	=	ncbi_scrub_se.ncbi_scrub_docker
+			Int		human_sports_removed = ncbi_scrub_se.read1_human_spots_removed
 
 			Float	kraken_human_dehosted	=	kraken2.percent_human
 			Float	kraken_sc2_dehosted	=	kraken2.percent_sc2

--- a/workflows/wf_read_QC_trim.wdl
+++ b/workflows/wf_read_QC_trim.wdl
@@ -17,11 +17,17 @@ workflow read_QC_trim {
     Int?    trimmomatic_quality_trim_score = 30
     Int?    trimmomatic_window_size = 4
   }
-  call read_clean.trimmomatic {
+  call read_clean.ncbi_scrub_pe {
     input:
       samplename = samplename,
       read1 = read1_raw,
-      read2 = read2_raw,
+      read2 = read2_raw
+  }  
+  call read_clean.trimmomatic {
+    input:
+      samplename = samplename,
+      read1 = ncbi_scrub_pe.read1_dehosted,
+      read2 = ncbi_scrub_pe.read2_dehosted,
       trimmomatic_minlen = trimmomatic_minlen,
       trimmomatic_quality_trim_score = trimmomatic_quality_trim_score,
       trimmomatic_window_size = trimmomatic_window_size
@@ -48,7 +54,18 @@ workflow read_QC_trim {
       read1 = read1_raw,
       read2 = read2_raw
   }
+  call taxonID.kraken2 as kraken2_dehosted {
+    input:
+      samplename = samplename,
+      read1 = ncbi_scrub_pe.read1_dehosted,
+      read2 = ncbi_scrub_pe.read2_dehosted
+  }
   output {
+    File  read1_dehosted = ncbi_scrub_pe.read1_dehosted
+    File  read2_dehosted = ncbi_scrub_pe.read2_dehosted
+    Int   read1_human_spots_removed = ncbi_scrub_pe.read1_human_spots_removed
+    Int   read2_human_spots_removed = ncbi_scrub_pe.read2_human_spots_removed
+    
     File	read1_clean	=	bbduk.read1_clean
     File	read2_clean	=	bbduk.read2_clean
 
@@ -64,6 +81,9 @@ workflow read_QC_trim {
     Float	kraken_human	=	kraken2_raw.percent_human
     Float	kraken_sc2	=	kraken2_raw.percent_sc2
     String	kraken_report	=	kraken2_raw.kraken_report
+    Float	kraken_human_dehosted	=	kraken2_dehosted.percent_human
+    Float	kraken_sc2_dehosted	=	kraken2_dehosted.percent_sc2
+    String	kraken_report_dehosted	=	kraken2_dehosted.kraken_report
 
     String	fastqc_version	=	fastqc_raw.version
     String	bbduk_docker	=	bbduk.bbduk_docker

--- a/workflows/wf_titan_clearlabs.wdl
+++ b/workflows/wf_titan_clearlabs.wdl
@@ -25,10 +25,24 @@ workflow titan_clearlabs {
     input:
       read1 = clear_lab_fastq
   }
+  call read_clean.ncbi_scrub_se {
+    input:
+      samplename = samplename,
+      read1 = clear_lab_fastq
+  }
+  call qc_utils.fastqc_se as fastqc_se_clean {
+    input:
+      read1 = ncbi_scrub_se.read1_dehosted
+  }
+  call taxon_ID.kraken2 as kraken2_dehosted {
+    input:
+      samplename = samplename,
+      read1 = ncbi_scrub_se.read1_dehosted
+  }
   call medaka.consensus {
     input:
       samplename = samplename,
-      filtered_reads = clear_lab_fastq,
+      filtered_reads = ncbi_scrub_se.read1_dehosted,
       artic_primer_version = artic_primer_version,
       normalise = normalise
   }
@@ -69,12 +83,18 @@ workflow titan_clearlabs {
   output {
     String	seq_platform	=	seq_method
 
-    Int fastqc_raw = fastqc_se_raw.number_reads
+    File	dehosted_reads	=	ncbi_scrub_se.read1_dehosted
 
+    Int fastqc_raw = fastqc_se_raw.number_reads
+    Int fastqc_clean = fastqc_se_clean.number_reads
+    
   	String	kraken_version	=	kraken2_raw.version
   	Float	kraken_human	=	kraken2_raw.percent_human
   	Float	kraken_sc2	=	kraken2_raw.percent_sc2
   	String	kraken_report	=	kraken2_raw.kraken_report
+    Float	kraken_human_dehosted	=	kraken2_dehosted.percent_human
+  	Float	kraken_sc2_dehosted	=	kraken2_dehosted.percent_sc2
+  	String	kraken_report_dehosted	=	kraken2_dehosted.kraken_report
 
   	File	aligned_bam	=	consensus.trim_sorted_bam
   	File	aligned_bai	=	consensus.trim_sorted_bai

--- a/workflows/wf_titan_illumina_pe.wdl
+++ b/workflows/wf_titan_illumina_pe.wdl
@@ -87,8 +87,6 @@ workflow titan_illumina_pe {
   
   File  read1_dehosted  = read_QC_trim.read1_dehosted
   File  read2_dehosted  = read_QC_trim.read2_dehosted
-  Int   read1_human_spots_removed = read_QC_trim.read1_human_spots_removed
-  Int   read2_human_spots_removed = read_QC_trim.read2_human_spots_removed
   File	read1_clean	=	read_QC_trim.read1_clean
   File	read2_clean	=	read_QC_trim.read2_clean
   Int	fastqc_raw1	=	read_QC_trim.fastqc_raw1

--- a/workflows/wf_titan_illumina_pe.wdl
+++ b/workflows/wf_titan_illumina_pe.wdl
@@ -84,7 +84,11 @@ workflow titan_illumina_pe {
   output {
 
   String	seq_platform	=	seq_method
-
+  
+  File  read1_dehosted  = read_QC_trim.read1_dehosted
+  File  read2_dehosted  = read_QC_trim.read2_dehosted
+  Int   read1_human_spots_removed = read_QC_trim.read1_human_spots_removed
+  Int   read2_human_spots_removed = read_QC_trim.read2_human_spots_removed
   File	read1_clean	=	read_QC_trim.read1_clean
   File	read2_clean	=	read_QC_trim.read2_clean
   Int	fastqc_raw1	=	read_QC_trim.fastqc_raw1
@@ -102,6 +106,9 @@ workflow titan_illumina_pe {
   Float	kraken_human	=	read_QC_trim.kraken_human
   Float	kraken_sc2	=	read_QC_trim.kraken_sc2
   String	kraken_report	=	read_QC_trim.kraken_report
+  Float	kraken_human_dehosted	=	read_QC_trim.kraken_human_dehosted
+  Float	kraken_sc2_dehosted	=	read_QC_trim.kraken_sc2_dehosted
+  String	kraken_report_dehosted	=	read_QC_trim.kraken_report_dehosted
 
   String	bwa_version	=	bwa.bwa_version
   String	sam_version	=	bwa.sam_version


### PR DESCRIPTION
Adopt latest version of the NCBI SRA-Human-Scrubber tool that addressed previous issue with inadvertent impact the quality of SC2 genome assemblies generated with the Titan workflows for genomic characterization:
- Updates to the `ncbi_scrub_pe` and `ncbi_scrub_se` tasks:
    - NCBI Scrubber docker tag updated to latest release: ncbi/sra-human-scrubber:1.0.2021-05-05
    - `-n` flag invoked with `scrubber.sh` command to ensure that human reads are replaced with IUPAC N rather than fully removed from read files
    - Additional outputs to capture the number of human sports removed 
- Modified workflows to account for task changes:
    - Stand alone workflows `ncbi_scrub_pe` and `ncbi_scrub_se` modified to output number of human spots removed
    - `Titan_Illumina_PE`, `Titan_ONT` & `Titan_ClearLabs` modified to incorporate host-removal as first step; extra kraken run after dehosting to check %human/SC2 
        - New outputs for `Titan_ClearLabs` & `Titan_ONT`: `dehosted_reads`, `fastqc_clean`, `kraken_human_deshoted`, `kraken_sc2_dehosted`, `kraken_report_deshoted` 
        - New outputs for `Titan_Illumina_PE`: `dehosted_read1`, `dehosted_read2`, `kraken_human_deshoted`, `kraken_sc2_dehosted`, `kraken_report_deshoted` 
    - Note: the updated NCBI scrubber tasks were not incoporated into the `Titan_Illumina_SE` workflow since the smaller size read data are not compatable with host-removal with this tool  
Other code modifications:
- Updated default `minlength` for the `trimmomatic` task to 75
    - No workflows impacted as explicit minlengths are provided in the workflows that utilize this task