### PR TITLE
Remove bedtools.cov task

### DIFF
--- a/tasks/task_pe_pub_repo_submission.wdl
+++ b/tasks/task_pe_pub_repo_submission.wdl
@@ -141,7 +141,7 @@ task genbank {
     isolate=$(echo ~{submission_id} | awk 'BEGIN { FS = "-" } ; {$1=$2=""; print $0}' | sed 's/^ *//g')
 
     # removing leading Ns, folding sequencing to 75 bp wide, and adding metadata for genbank submissions
-    echo ">~{submission_id} [organism=~{organism}][isolate=~{iso_org}/~{iso_host}/~{iso_country}/~{submission_id}/~year)][host=~{iso_host}][country=~{iso_country}][collection_date=~{collection_date}]" > ~{submission_id}.genbank.fa
+    echo ">~{submission_id} [organism=~{organism}][isolate=~{iso_org}/~{iso_host}/~{iso_country}/~{submission_id}/~{year})][host=~{iso_host}][country=~{iso_country}][collection_date=~{collection_date}]" > ~{submission_id}.genbank.fa
     grep -v ">" ~{sequence} | sed 's/^N*N//g' | fold -w 75 >> ~{submission_id}.genbank.fa
 
     echo Sequence_ID,Country,Host,Isolate,Collection Date, BioProject Accession > ~{submission_id}.genbankMeta.csv

--- a/tasks/task_pe_pub_repo_submission.wdl
+++ b/tasks/task_pe_pub_repo_submission.wdl
@@ -141,7 +141,7 @@ task genbank {
     isolate=$(echo ~{submission_id} | awk 'BEGIN { FS = "-" } ; {$1=$2=""; print $0}' | sed 's/^ *//g')
 
     # removing leading Ns, folding sequencing to 75 bp wide, and adding metadata for genbank submissions
-    echo ">~{submission_id} [organism=~{organism}][isolate=~{iso_org}/~{iso_host}/~{iso_country}/~{submission_id}/~{year})][host=~{iso_host}][country=~{iso_country}][collection_date=~{collection_date}]" > ~{submission_id}.genbank.fa
+    echo ">~{submission_id} [organism=~{organism}][isolate=~{iso_org}/~{iso_host}/~{iso_country}/~{submission_id}/$year)][host=~{iso_host}][country=~{iso_country}][collection_date=~{collection_date}]" > ~{submission_id}.genbank.fa
     grep -v ">" ~{sequence} | sed 's/^N*N//g' | fold -w 75 >> ~{submission_id}.genbank.fa
 
     echo Sequence_ID,Country,Host,Isolate,Collection Date, BioProject Accession > ~{submission_id}.genbankMeta.csv

--- a/workflows/wf_titan_illumina_pe.wdl
+++ b/workflows/wf_titan_illumina_pe.wdl
@@ -72,11 +72,6 @@ workflow titan_illumina_pe {
     input:
       genome_fasta = consensus.consensus_seq
   }
-  call amplicon_metrics.bedtools_cov {
-    input:
-      bamfile = bwa.sorted_bam,
-      baifile = bwa.sorted_bai
-  }
   call ncbi.vadr {
     input:
       genome_fasta = consensus.consensus_seq,

--- a/workflows/wf_titan_illumina_se.wdl
+++ b/workflows/wf_titan_illumina_se.wdl
@@ -68,11 +68,6 @@ workflow titan_illumina_se {
     input:
       genome_fasta = consensus.consensus_seq
   }
-  call amplicon_metrics.bedtools_cov {
-    input:
-      bamfile = bwa.sorted_bam,
-      baifile = bwa.sorted_bai
-  }
   call ncbi.vadr {
     input:
       genome_fasta = consensus.consensus_seq,

--- a/workflows/wf_titan_ont.wdl
+++ b/workflows/wf_titan_ont.wdl
@@ -10,7 +10,7 @@ import "../tasks/task_qc_utils.wdl" as qc_utils
 
 workflow titan_ont {
   meta {
-    description: "Reference-based consensus calling for viral amplicon ont sequencing data generated on the Clear Labs platform."
+    description: "Reference-based consensus calling for viral amplicon ont sequencing data generated on ONT NGS platforms."
   }
 
   input {


### PR DESCRIPTION
Remove bedtools.cov task no longer utilized in the Titan workflows for Genomic Characterization 

Other minor changes:
- Update Titan_ONT documentation; grab proper header for GenBank assemblies