### PR TITLE
mem retry 3 all tasks phvg

### DIFF
--- a/tasks/task_alignment.wdl
+++ b/tasks/task_alignment.wdl
@@ -40,6 +40,7 @@ task bwa {
     cpu:          2
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 
@@ -72,5 +73,6 @@ task mafft {
     cpu:          16
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }

--- a/tasks/task_assembly_metrics.wdl
+++ b/tasks/task_assembly_metrics.wdl
@@ -51,6 +51,7 @@ task stats_n_coverage {
     memory:       "8 GB"
     cpu:          2
     disks:        "local-disk 100 SSD"
-    preemptible:  0      
+    preemptible:  0
+    maxRetries:   3
   }
 }

--- a/tasks/task_consensus_call.wdl
+++ b/tasks/task_consensus_call.wdl
@@ -53,6 +53,7 @@ task primer_trim {
     cpu:          2
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 
@@ -113,6 +114,7 @@ task variant_call {
     cpu:          2
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 
@@ -196,5 +198,6 @@ task consensus {
     cpu:          2
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }

--- a/tasks/task_data_vis.wdl
+++ b/tasks/task_data_vis.wdl
@@ -59,5 +59,6 @@ task cluster_render {
     cpu:          2
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }

--- a/tasks/task_ncbi.wdl
+++ b/tasks/task_ncbi.wdl
@@ -59,5 +59,6 @@ task vadr {
     memory: "2 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 3
   }
 }

--- a/tasks/task_ont_medaka.wdl
+++ b/tasks/task_ont_medaka.wdl
@@ -25,6 +25,7 @@ task demultiplexing {
     cpu:          8
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 
@@ -59,6 +60,7 @@ task read_filtering {
     cpu:          8
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 
@@ -131,5 +133,6 @@ task consensus {
     cpu:          8
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }

--- a/tasks/task_pe_pub_repo_submission.wdl
+++ b/tasks/task_pe_pub_repo_submission.wdl
@@ -45,6 +45,7 @@ task deidentify {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries:   3
   }
 }
 
@@ -112,6 +113,7 @@ task gisaid {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries:   3
   }
 }
 
@@ -161,6 +163,7 @@ task genbank {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries:   3
   }
 }
 
@@ -199,6 +202,7 @@ task sra {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries:   3
   }
 }
 
@@ -258,5 +262,6 @@ input {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries:   3
   }
 }

--- a/tasks/task_phylo.wdl
+++ b/tasks/task_phylo.wdl
@@ -28,6 +28,7 @@ task snp_dists {
     cpu:          2
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 
@@ -66,5 +67,6 @@ task iqtree {
     cpu:          4
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }

--- a/tasks/task_qc_utils.wdl
+++ b/tasks/task_qc_utils.wdl
@@ -49,6 +49,7 @@ task fastqc {
     cpu:          2
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 task fastqc_se {
@@ -87,5 +88,6 @@ task fastqc_se {
     cpu:          2
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }

--- a/tasks/task_read_clean.wdl
+++ b/tasks/task_read_clean.wdl
@@ -63,6 +63,7 @@ task ncbi_scrub_pe {
       cpu:          4
       disks:        "local-disk 100 SSD"
       preemptible:  0
+      maxRetries:   3
   }
 }
 
@@ -109,6 +110,7 @@ task ncbi_scrub_se {
       cpu:          4
       disks:        "local-disk 100 SSD"
       preemptible:  0
+      maxRetries:   3
   }
 }
 
@@ -163,6 +165,7 @@ task seqyclean {
       cpu:          2
       disks:        "local-disk 100 SSD"
       preemptible:  0
+      maxRetries:   3
   }
 }
 
@@ -206,6 +209,7 @@ task trimmomatic {
       cpu:          4
       disks:        "local-disk 100 SSD"
       preemptible:  0
+      maxRetries:   3
   }
 }
 task trimmomatic_se {
@@ -246,6 +250,7 @@ task trimmomatic_se {
       cpu:          4
       disks:        "local-disk 100 SSD"
       preemptible:  0
+      maxRetries:   3
   }
 }
 task bbduk {
@@ -284,6 +289,7 @@ task bbduk {
       cpu:          4
       disks:        "local-disk 100 SSD"
       preemptible:  0
+      maxRetries:   3
   }
 }
 task bbduk_se {
@@ -318,5 +324,6 @@ task bbduk_se {
       cpu:          4
       disks:        "local-disk 100 SSD"
       preemptible:  0
+      maxRetries:   3
   }
 }

--- a/tasks/task_se_pub_repo_submission.wdl
+++ b/tasks/task_se_pub_repo_submission.wdl
@@ -45,6 +45,7 @@ task deidentify {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries:   3
   }
 }
 
@@ -112,6 +113,7 @@ task gisaid {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries:   3
   }
 }
 
@@ -161,6 +163,7 @@ task genbank {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries:   3
   }
 }
 
@@ -191,6 +194,7 @@ task sra {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries:   3
   }
 }
 
@@ -305,5 +309,6 @@ task compile {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries:   3
   }
 }

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -49,6 +49,7 @@ task kraken2 {
     cpu:          4
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 
@@ -91,6 +92,7 @@ task pangolin {
     cpu:          4
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 
@@ -150,6 +152,7 @@ task pangolin2 {
     cpu:          4
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 
@@ -226,6 +229,7 @@ task pangolin3 {
     cpu:          4
     disks:        "local-disk 100 SSD"
     preemptible:  0
+    maxRetries:   3
   }
 }
 
@@ -285,6 +289,7 @@ task nextclade_one_sample {
         cpu:    2
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+	maxRetries:   3
     }
     output {
         String nextclade_version  = read_string("VERSION")

--- a/tasks/task_titan_summary.wdl
+++ b/tasks/task_titan_summary.wdl
@@ -126,6 +126,7 @@ task titan_summary {
         memory: "1 GB"
         cpu: 1
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 3
     }
 }
 
@@ -180,5 +181,6 @@ task merge_titan_summary {
         memory: "1 GB"
         cpu: 1
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 3
     }
 }

--- a/tasks/task_versioning.wdl
+++ b/tasks/task_versioning.wdl
@@ -22,6 +22,7 @@ task version_capture {
     cpu: 1
     docker: "theiagen/utility:1.1"
     disks: "local-disk 10 HDD"
-    dx_instance_type: "mem1_ssd1_v2_x2" 
+    dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 3
   }
 }

--- a/tasks/tasks_intrahost.wdl
+++ b/tasks/tasks_intrahost.wdl
@@ -36,6 +36,7 @@ task isnvs_per_sample {
     docker: "${docker}"
     memory: select_first([machine_mem_gb, 7]) + " GB"
     dx_instance_type: "mem1_ssd1_v2_x8"
+    maxRetries: 3
   }
 }
 
@@ -113,6 +114,7 @@ task isnvs_vcf {
     docker: "${docker}"
     memory: select_first([machine_mem_gb, 4]) + " GB"
     dx_instance_type: "mem1_ssd1_v2_x4"
+    maxRetries: 3
   }
 }
 
@@ -204,5 +206,6 @@ task annotate_vcf_snpeff {
     memory: select_first([machine_mem_gb, 4]) + " GB"
     disks:  "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x4"
+    maxRetries: 3
   }
 }

--- a/tasks/tasks_nextstrain.wdl
+++ b/tasks/tasks_nextstrain.wdl
@@ -251,7 +251,7 @@ task fasta_to_ids {
         memory: "1 GB"
         cpu:    1
         disks: "local-disk 375 LOCAL"
-        dx_instance_type: "mem1_ssd1_v2_x2
+        dx_instance_type: "mem1_ssd1_v2_x2"
         maxRetries: 3
     }
     output {
@@ -432,6 +432,7 @@ task nextstrain_ncov_defaults {
         cpu :   1
         disks:  "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries:   3
     }
     output {
         File clades_tsv      = "clades-with-subclades.tsv"

--- a/tasks/tasks_nextstrain.wdl
+++ b/tasks/tasks_nextstrain.wdl
@@ -17,6 +17,7 @@ task concatenate {
         cpu:    1
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 3
     }
     output {
         File combined = "${output_name}"
@@ -48,6 +49,7 @@ task gzcat {
         cpu:    2
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 3
     }
     output {
         File combined = "${output_name}"
@@ -114,6 +116,7 @@ task nextmeta_prep {
     memory: "1 GB"
     cpu: 1
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 3
   }
 }
 
@@ -225,6 +228,7 @@ task derived_cols {
         cpu:    1
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 3
     }
     output {
         File derived_metadata = "~{basename}.derived_cols.tsv"
@@ -247,7 +251,8 @@ task fasta_to_ids {
         memory: "1 GB"
         cpu:    1
         disks: "local-disk 375 LOCAL"
-        dx_instance_type: "mem1_ssd1_v2_x2"
+        dx_instance_type: "mem1_ssd1_v2_x2
+        maxRetries: 3
     }
     output {
         File ids_txt = "~{basename}.txt"
@@ -293,6 +298,7 @@ task filter_segments {
         cpu:    1
         disks: "local-disk 375 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 3
     }
     output {
         File assembly_of_segment = stdout()
@@ -394,6 +400,7 @@ task nextstrain_build_subsample {
         cpu :   4
         disks:  "local-disk 375 HDD"
         dx_instance_type: "mem3_ssd1_v2_x16"
+        maxRetries: 3
     }
     output {
         File   subsampled_msa = "ncov/results/~{build_name}/subsampled_alignment.fasta"
@@ -521,6 +528,7 @@ task filter_subsample_sequences {
         disks:  "local-disk 100 HDD"
         dx_instance_type: "mem1_ssd1_v2_x4"
         preemptible: 1
+        maxRetries: 3
     }
     output {
         File   filtered_fasta    = out_fname
@@ -583,6 +591,7 @@ task filter_sequences_by_length {
         cpu :   1
         disks:  "local-disk 300 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 3
     }
     output {
         File   filtered_fasta    = out_fname
@@ -666,6 +675,7 @@ task filter_sequences_to_list {
         disks:  "local-disk 200 HDD"
         dx_instance_type: "mem1_ssd1_v2_x4"
         preemptible: 1
+        maxRetries: 3
     }
     output {
         File   filtered_fasta    = out_fname
@@ -752,6 +762,7 @@ task mafft_one_chr {
         disks:  "local-disk 375 LOCAL"
         preemptible: 0
         dx_instance_type: "mem3_ssd1_v2_x36"
+        maxRetries: 3
     }
     output {
         File   aligned_sequences = "~{basename}_aligned.fasta"
@@ -798,6 +809,7 @@ task augur_mafft_align {
         disks:  "local-disk 750 LOCAL"
         preemptible: 0
         dx_instance_type: "mem3_ssd2_v2_x32"
+        maxRetries: 3
     }
     output {
         File   aligned_sequences = "~{basename}_aligned.fasta"
@@ -826,6 +838,7 @@ task snp_sites {
         disks:  "local-disk 100 HDD"
         preemptible: 0
         dx_instance_type: "mem3_ssd1_v2_x4"
+        maxRetries: 3
     }
     output {
         File   snps_vcf = "~{out_basename}.vcf"
@@ -872,6 +885,7 @@ task augur_mask_sites {
         disks:  "local-disk 100 HDD"
         preemptible: 1
         dx_instance_type: "mem1_ssd1_v2_x4"
+        maxRetries: 3
     }
     output {
         File   masked_sequences = out_fname
@@ -927,6 +941,7 @@ task draft_augur_tree {
         disks:  "local-disk 750 LOCAL"
         dx_instance_type: "mem1_ssd1_v2_x36"
         preemptible: 0
+        maxRetries: 3
     }
     output {
         File   aligned_tree = "~{out_basename}_~{method}.nwk"
@@ -1007,6 +1022,7 @@ task refine_augur_tree {
         disks:  "local-disk 100 HDD"
         dx_instance_type: "mem3_ssd1_v2_x8"
         preemptible: 0
+        maxRetries: 3
     }
     output {
         File   tree_refined  = "~{out_basename}_timetree.nwk"
@@ -1056,6 +1072,7 @@ task ancestral_traits {
         disks:  "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 1
+        maxRetries: 3
     }
     output {
         File   node_data_json = "~{out_basename}_ancestral_traits.json"
@@ -1115,6 +1132,7 @@ task ancestral_tree {
         disks:  "local-disk 50 HDD"
         dx_instance_type: "mem3_ssd1_v2_x8"
         preemptible: 0
+        maxRetries: 3
     }
     output {
         File   nt_muts_json = "~{out_basename}_nt_muts.json"
@@ -1161,6 +1179,7 @@ task translate_augur_tree {
         disks:  "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 1
+        maxRetries: 3
     }
     output {
         File   aa_muts_json = "~{out_basename}_aa_muts.json"
@@ -1228,6 +1247,7 @@ task tip_frequencies {
         disks:  "local-disk 100 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 1
+        maxRetries: 3
     }
     output {
         File   node_data_json = "~{out_basename}_tip-frequencies.json"
@@ -1270,6 +1290,7 @@ task assign_clades_to_nodes {
         disks:  "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 1
+        maxRetries: 3
     }
     output {
         File   node_clade_data_json = "~{out_basename}_clades.json"
@@ -1316,6 +1337,7 @@ task augur_import_beast {
         disks:  "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 1
+        maxRetries: 3
     }
     output {
         File   tree_newick    = "~{tree_basename}.nwk"
@@ -1414,6 +1436,7 @@ task export_auspice_json {
         disks:  "local-disk 100 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
         preemptible: 0
+        maxRetries: 3
     }
     output {
         File   virus_json = "~{out_basename}_auspice.json"
@@ -1470,5 +1493,6 @@ task prep_augur_metadata {
       cpu:          CPUs
       disks:        "local-disk ~{disk_size} SSD"
       preemptible:  preemptible_tries
+      maxRetries: 3
   }
 }

--- a/tasks/tasks_reports.wdl
+++ b/tasks/tasks_reports.wdl
@@ -76,6 +76,7 @@ task plot_coverage {
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x4"
     preemptible: 1
+    maxRetries: 3
   }
 }
 
@@ -107,6 +108,7 @@ task coverage_report {
     cpu: 2
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd2_v2_x4"
+    maxRetries: 3
   }
 }
 
@@ -137,6 +139,7 @@ task assembly_bases {
         cpu: 1
         disks: "local-disk 50 HDD"
         dx_instance_type: "mem1_ssd1_v2_x2"
+        maxRetries: 3
     }
 }
 
@@ -167,6 +170,7 @@ task fastqc {
     docker: "${docker}"
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 3
   }
 }
 
@@ -213,6 +217,7 @@ task align_and_count {
     docker: "${docker}"
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x4"
+    maxRetries: 3
   }
 }
 
@@ -241,6 +246,7 @@ task align_and_count_summary {
     docker: "${docker}"
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 3
   }
 }
 
@@ -288,6 +294,7 @@ task aggregate_metagenomics_reports {
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd2_v2_x2"
     preemptible: 0
+    maxRetries: 3
   }
 }
 
@@ -384,6 +391,7 @@ task MultiQC {
     docker: "${docker}"
     disks: "local-disk 375 LOCAL"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 3
   }
 }
 
@@ -452,6 +460,7 @@ task tsv_join {
     docker: "python:slim"
     disks: "local-disk 100 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 3
   }
 }
 
@@ -479,6 +488,7 @@ task tsv_stack {
     docker: "${docker}"
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
+    maxRetries: 3
   }
 
 }
@@ -516,5 +526,6 @@ task compare_two_genomes {
     disks: "local-disk 50 HDD"
     dx_instance_type: "mem1_ssd1_v2_x2"
     preemptible: 1
+    maxRetries: 3
   }
 }


### PR DESCRIPTION
Added maxRetries: 3 runtime parameter to all tasks. This will allow all phvg workflows to utilize the retry with more memory option available on terra.bio. these changes have been validated using the miniwdl check on fja's local device, and were also validated using the workflow validation sets in the workspace_validations workspace on terra.


In runtime block
```maxRetries: 3```
was added
