### PR TITLE
remove prebuild of Singularity images

### DIFF
--- a/bin/titan-gc-cli
+++ b/bin/titan-gc-cli
@@ -87,35 +87,6 @@ if [[ "${CONFIG}" == "0" ]]; then
         CONFIG_PATH="${TITAN_SHARE}/conf/docker.config"
     elif [[ "${PROFILE}" == "singularity" ]]; then
         CONFIG_PATH="${TITAN_SHARE}/conf/singularity.config"
-        if [[ -z ${SINGULARITY_CACHEDIR+x} ]]; then 
-            CACHE_DIR=${SINGULARITY_CACHE}
-        else 
-            CACHE_DIR=${SINGULARITY_CACHEDIR}
-        fi
-        # Check if images are built
-        mkdir -p ${CACHE_DIR}
-        WARNED="0"
-        while IFS=$'\t' read -r container version sha256_hash; do
-            container_name="${container}:${version}"
-            renamed=${container_name//[\/:]/-}
-            IMAGE="${CACHE_DIR}/${renamed}.img"
-            if [[ ! -f ${IMAGE} ]]; then
-                if [[ ${WARNED} == "0" ]]; then
-                    echo "Building Singularity images, this will be a while... Coffee time?" 1>&2
-                    WARNED="1"
-                fi
-                echo "Building Singularity image: ${IMAGE}" 1>&2
-                if [[ ${QUIET} == "0" ]]; then
-                    singularity build ${IMAGE} docker://${container_name}
-                else
-                    singularity build ${IMAGE} docker://${container_name} 1> /dev/null
-                fi
-            else
-                if [[ ${QUIET} == "0" ]]; then
-                    echo "Skipping build of existing Singularity image: ${IMAGE}" 1>&2
-                fi
-            fi
-        done < ${TITAN_SHARE}/conf/containers.txt
     else
         echo "Uknown profile: ${PROFILE}, exiting..."
         usage 1


### PR DESCRIPTION
This was originally implemented to address pull limits, which should no longer be an issue.

If it becomes an issue, I will add a separate script to prebuild singularity images