### PR TITLE
Capture pangolin updates

### DIFF
--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -246,7 +246,7 @@ task pangolin_update_log {
   }
 
   command <<<
-    # set inference inference_engine
+    # set timezone for date outputs
     ~{default='' 'export TZ=' + timezone}
     DATE=$(date +"%Y-%m-%d")
     

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -266,7 +266,7 @@ task pangolin_update_log {
      else 
        echo "No lineage log provided; creating new lineage log file"
        echo -e "analysis_date\tmodification_status\tprevious_lineage\tprevious_pangolin_docker\tprevious_pangolin_version\tupdated_lineage\tupdated_pangolin_docker\tupdated_pangolin_version" > "~{samplename}_pango_lineage.log"
-       lienage_log_file="pango_lineage.log"
+       lienage_log_file="~{samplename}_pango_lineage.log"
      fi
      
      #populate lineage log file

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -259,7 +259,7 @@ task pangolin_update_log {
     fi
     
     #if a lineage log not provided, create one with headers
-    if [ -f "~{lineage_log}"]
+    if [ -s "~{lineage_log}"]
     then 
       echo "Lineage log provided"
       lineage_log_file="~{lineage_log}"

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -253,9 +253,9 @@ task pangolin_update_log {
     #check if lineage has been modified 
     if [[ "~{current_lineage}" == "~{updated_lineage}" ]]
     then 
-      UPDATE_STATUS="pango_lineage unchanged: ~{updated_lineage}"
+      UPDATE_STATUS="pango lineage unchanged: ~{updated_lineage}"
     else 
-      UPDATE_STATUS="pango_lineage modified: ~{current_lineage} -> ~{updated_lineage}"
+      UPDATE_STATUS="pango lineage modified: ~{current_lineage} -> ~{updated_lineage}"
     fi
     
     #if a lineage log not provided, create one with headers

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -270,7 +270,7 @@ task pangolin_update_log {
      fi
      
      #populate lineage log file
-     echo -e "${DATE}\t${STATUS}\t~{current_lineage}\t~{current_pangolin_docker}\t~{current_pangolin_version}\t~{updated_lineage}\t~{updated_pangolin_docker}\t~{updated_pangolin_version}" >> "${lineage_log_file}"
+     echo -e "${DATE}\t${UPDATE_STATUS}\t~{current_lineage}\t~{current_pangolin_docker}\t~{current_pangolin_version}\t~{updated_lineage}\t~{updated_pangolin_docker}\t~{updated_pangolin_version}" >> "${lineage_log_file}"
      
     echo "${UPDATE_STATUS} (${DATE})"  | tee PANGOLIN_UPDATE       
 

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -253,7 +253,7 @@ task pangolin_update_log {
     #check if lineage has been modified 
     if [[ "~{current_lineage}" == "~{updated_lineage}" ]]
     then 
-      UPDATE_STATUS="pango_lineage unchanged"
+      UPDATE_STATUS="pango_lineage unchanged: ~{updated_lineage}"
     else 
       UPDATE_STATUS="pango_lineage modified: ~{current_lineage} -> ~{updated_lineage}"
     fi

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -259,14 +259,15 @@ task pangolin_update_log {
     fi
     
     #if a lineage log not provided, create one with headers
+    lineage_log_file="~{samplename}_pango_lineage_log.tsv"
+    
     if [ -s "~{lineage_log}" ]
     then 
       echo "Lineage log provided"
-      lineage_log_file="~{lineage_log}"
+      mv "~{lineage_log}" ${lineage_log_file}
      else 
-       echo "No lineage log provided; creating new lineage log file"
-       echo -e "analysis_date\tmodification_status\tprevious_lineage\tprevious_pangolin_docker\tprevious_pangolin_version\tupdated_lineage\tupdated_pangolin_docker\tupdated_pangolin_version" > "~{samplename}_pango_lineage_log.tsv"
-       lineage_log_file="~{samplename}_pango_lineage_log.tsv"
+       echo "Creating new lineage log file as none was provided"
+       echo -e "analysis_date\tmodification_status\tprevious_lineage\tprevious_pangolin_docker\tprevious_pangolin_version\tupdated_lineage\tupdated_pangolin_docker\tupdated_pangolin_version" > ${lineage_log_file}
      fi
      
      #populate lineage log file

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -241,11 +241,13 @@ task pangolin_update_log {
     String updated_lineage
     String updated_pangolin_docker
     String updated_pangolin_version
+    String? timezone
     File?  lineage_log
   }
 
   command <<<
     # set inference inference_engine
+    ~{default='' 'export TZ=' + timezone}
     DATE=$(date +"%Y-%m-%d")
     
     #check if lineage has been modified 

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -266,7 +266,7 @@ task pangolin_update_log {
      else 
        echo "No lineage log provided; creating new lineage log file"
        echo -e "analysis_date\tmodification_status\tprevious_lineage\tprevious_pangolin_docker\tprevious_pangolin_version\tupdated_lineage\tupdated_pangolin_docker\tupdated_pangolin_version" > "~{samplename}_pango_lineage.log"
-       lienage_log_file="~{samplename}_pango_lineage.log"
+       lineage_log_file="~{samplename}_pango_lineage.log"
      fi
      
      #populate lineage log file

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -265,8 +265,8 @@ task pangolin_update_log {
       lineage_log_file="~{lineage_log}"
      else 
        echo "No lineage log provided; creating new lineage log file"
-       echo -e "analysis_date\tmodification_status\tprevious_lineage\tprevious_pangolin_docker\tprevious_pangolin_version\tupdated_lineage\tupdated_pangolin_docker\tupdated_pangolin_version" > "~{samplename}_pango_lineage.log"
-       lineage_log_file="~{samplename}_pango_lineage.log"
+       echo -e "analysis_date\tmodification_status\tprevious_lineage\tprevious_pangolin_docker\tprevious_pangolin_version\tupdated_lineage\tupdated_pangolin_docker\tupdated_pangolin_version" > "~{samplename}_pango_lineage_log.tsv"
+       lineage_log_file="~{samplename}_pango_lineage_log.tsv"
      fi
      
      #populate lineage log file
@@ -278,7 +278,7 @@ task pangolin_update_log {
 
   output {
     String     pangolin_updates = read_string("PANGOLIN_UPDATE")
-    File       pango_lineage_log = "~{samplename}_pango_lineage.log"
+    File       pango_lineage_log = "~{samplename}_pango_lineage_log.tsv"
   }
 
   runtime {

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -249,7 +249,7 @@ task pangolin_update_log {
     DATE=$(date +"%Y-%m-%d")
     
     #check if lineage has been modified 
-    if [[ "~{current_lineage}" == "{updated_lineage}" ]]
+    if [[ "~{current_lineage}" == "~{updated_lineage}" ]]
     then 
       UPDATE_STATUS="pango_lineage unchanged"
     else 
@@ -268,7 +268,7 @@ task pangolin_update_log {
      fi
      
      #populate lineage log file
-     echo -e "${DATE}\t${STATUS}\t~{current_lineage}\t~{current_pangolin_docker}\t~{current_pangolin_version}\t~{updated_lineage}\t~{updated_pangolin_docker}\t~{updated_pangolin_version}" >> ${lineage_log_file}
+     echo -e "${DATE}\t${STATUS}\t~{current_lineage}\t~{current_pangolin_docker}\t~{current_pangolin_version}\t~{updated_lineage}\t~{updated_pangolin_docker}\t~{updated_pangolin_version}" >> "${lineage_log_file}"
      
     echo "${UPDATE_STATUS} (${DATE})"  | tee PANGOLIN_UPDATE       
 

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -259,7 +259,7 @@ task pangolin_update_log {
     fi
     
     #if a lineage log not provided, create one with headers
-    if [ -s "~{lineage_log}"]
+    if [ -s "~{lineage_log}" ]
     then 
       echo "Lineage log provided"
       lineage_log_file="~{lineage_log}"

--- a/workflows/wf_pangolin_update.wdl
+++ b/workflows/wf_pangolin_update.wdl
@@ -11,6 +11,7 @@ workflow pangolin_update {
         String current_pangolin_docker
         String current_pangolin_version
         String  updated_pangolin_docker
+        String? timezone
         File? lineage_log
     }
 
@@ -29,6 +30,7 @@ workflow pangolin_update {
       updated_lineage = pangolin3.pangolin_lineage,
       updated_pangolin_docker = pangolin3.pangolin_docker,
       updated_pangolin_version = pangolin3.version,
+      timezone = timezone,
       lineage_log = lineage_log
     }
     call versioning.version_capture{

--- a/workflows/wf_pangolin_update.wdl
+++ b/workflows/wf_pangolin_update.wdl
@@ -16,25 +16,26 @@ workflow pangolin_update {
     }
 
     call taxon_ID.pangolin3 {
-    input:
+      input:
         samplename = samplename,
         fasta = assembly,
         docker = updated_pangolin_docker
     }
     call taxon_ID.pangolin_update_log {
-    input:
-      samplename = samplename,
-      current_lineage = current_lineage,
-      current_pangolin_docker = current_pangolin_docker,
-      current_pangolin_version = current_pangolin_version,
-      updated_lineage = pangolin3.pangolin_lineage,
-      updated_pangolin_docker = pangolin3.pangolin_docker,
-      updated_pangolin_version = pangolin3.version,
-      timezone = timezone,
-      lineage_log = lineage_log
+      input:
+        samplename = samplename,
+        current_lineage = current_lineage,
+        current_pangolin_docker = current_pangolin_docker,
+        current_pangolin_version = current_pangolin_version,
+        updated_lineage = pangolin3.pangolin_lineage,
+        updated_pangolin_docker = pangolin3.pangolin_docker,
+        updated_pangolin_version = pangolin3.version,
+        timezone = timezone,
+        lineage_log = lineage_log
     }
     call versioning.version_capture{
       input:
+        timezone = timezone
     }
     output {
         String pangolin_update_version            = version_capture.phvg_version

--- a/workflows/wf_pangolin_update.wdl
+++ b/workflows/wf_pangolin_update.wdl
@@ -7,7 +7,11 @@ workflow pangolin_update {
     input {
         String  samplename
         File    assembly
+        String current_lineage
+        String current_pangolin_docker
+        String current_pangolin_version
         String  updated_pangolin_docker
+        File lineage_log
     }
 
     call taxon_ID.pangolin3 {
@@ -16,17 +20,32 @@ workflow pangolin_update {
         fasta = assembly,
         docker = updated_pangolin_docker
     }
+    call taxon_ID.pangolin_update_log {
+    input:
+      samplename = samplename,
+      current_lineage = current_lineage,
+      current_pangolin_docker = current_pangolin_docker,
+      current_pangolin_version = current_pangolin_version,
+      updated_lineage = pangolin3.pangolin_lineage,
+      updated_pangolin_docker = pangolin3.pangolin_docker,
+      updated_pangolin_version = pangolin3.version,
+      lineage_log = lineage_log
+    }
     call versioning.version_capture{
       input:
     }
     output {
         String pangolin_update_version            = version_capture.phvg_version
         String pangolin_update_analysis_date      = version_capture.date
+        
         String pango_lineage        = pangolin3.pangolin_lineage
         String pangolin_conflicts   = pangolin3.pangolin_conflicts
         String pangolin_notes       = pangolin3.pangolin_notes
         String pangolin_version     = pangolin3.version
         File   pango_lineage_report = pangolin3.pango_lineage_report
         String pangolin_docker      = pangolin3.pangolin_docker
+        
+        String pangolin_updates = pangolin_update_log.pangolin_updates
+        File pango_lineage_log = pangolin_update_log.pango_lineage_log
     }
 }

--- a/workflows/wf_pangolin_update.wdl
+++ b/workflows/wf_pangolin_update.wdl
@@ -11,7 +11,7 @@ workflow pangolin_update {
         String current_pangolin_docker
         String current_pangolin_version
         String  updated_pangolin_docker
-        File lineage_log
+        File? lineage_log
     }
 
     call taxon_ID.pangolin3 {


### PR DESCRIPTION
Addresses #35:

Two new outputs created: 
- pangolin_updates: string that indicates if the lineage has been modified relative to the current assignment
- pango_lineage_log: file that captures the analysis date, modification status, lineage assignment, and all relevant pangolin version information for the current and updated lineage

To create these outputs, the Pangolin_Update workflow will require additional inpus:
- current_lineage
- current_pangolin_docker
- current_pangolin_version