### PR TITLE
CLI: titan-gc-prepare - check file exists, improve error messages

### DIFF
--- a/bin/titan-gc-prepare.py
+++ b/bin/titan-gc-prepare.py
@@ -129,8 +129,17 @@ if __name__ == '__main__':
         with open(EMPTY_FASTQ, 'a'):
             pass
 
+    if not os.path.exists(args.path) or not os.path.exists(args.primers):
+        if not os.path.exists(args.path):
+            print(f'Unable to locate {args.path}, please check spelling or verify it exists, and try again', file=sys.stderr)
+        if not os.path.exists(args.primers):
+            print(f'Unable to locate {args.primers}, please check spelling or verify it exists, and try again', file=sys.stderr)
+        sys.exit(1)
+
     # Match FASTQS
+    total_fastqs = 0
     for fastq in search_path(abspath, args.fastq_pattern, recursive=args.recursive):
+        total_fastqs += 1
         fastq_name = fastq.name.replace(args.fastq_ext, "")
         # Split the fastq file name on separator
         # Example MY_FASTQ_R1.rsplit('_', 1) becomes ['MY_FASTQ', 'R1'] (PE)
@@ -157,72 +166,81 @@ if __name__ == '__main__':
                 print(f'ERROR: Please use --pe1_pattern and --pe2_pattern to correct and try again.', file=sys.stderr)
                 sys.exit(1)
 
-    FOFN = []
-    for sample, vals in sorted(SAMPLES.items()):
-        r1_reads = vals['pe']['r1']
-        r2_reads = vals['pe']['r2']
-        se_reads = vals['se']
-        errors = []
-        pe_count = len(r1_reads) + len(r2_reads)
+    if total_fastqs:
+        FOFN = []
+        for sample, vals in sorted(SAMPLES.items()):
+            r1_reads = vals['pe']['r1']
+            r2_reads = vals['pe']['r2']
+            se_reads = vals['se']
+            errors = []
+            pe_count = len(r1_reads) + len(r2_reads)
 
-        # Validate everything
-        if len(r1_reads) != len(r2_reads):
-            # PE reads must be a pair
-            errors.append(f'ERROR: "{sample}" must have equal paired-end read sets (R1 has {len(r1_reads)} and R2 has {len(r2_reads)}, please check.')
-        elif pe_count > 2:
-            # PE reads must be a pair
-            errors.append(f'ERROR: "{sample}" cannot have more than two paired-end FASTQ, please check.')
+            # Validate everything
+            if len(r1_reads) != len(r2_reads):
+                # PE reads must be a pair
+                errors.append(f'ERROR: "{sample}" must have equal paired-end read sets (R1 has {len(r1_reads)} and R2 has {len(r2_reads)}, please check.')
+            elif pe_count > 2:
+                # PE reads must be a pair
+                errors.append(f'ERROR: "{sample}" cannot have more than two paired-end FASTQ, please check.')
 
-        if len(se_reads) > 1:
-            # Can't have multiple SE reads
-            errors.append(f'ERROR: "{sample}" has more than two single-end FASTQs, please check.')
-        elif pe_count and len(se_reads):
-            # Can't have SE and PE reads unless long reads
-            errors.append(f'ERROR: "{sample}" has paired and single-end FASTQs, please check.')
+            if len(se_reads) > 1:
+                # Can't have multiple SE reads
+                errors.append(f'ERROR: "{sample}" has more than two single-end FASTQs, please check.')
+            elif pe_count and len(se_reads):
+                # Can't have SE and PE reads unless long reads
+                errors.append(f'ERROR: "{sample}" has paired and single-end FASTQs, please check.')
 
-        if errors:
-            print('\n'.join(errors), file=sys.stderr)
-        else:
-            r1 = ''
-            r2 = ''
+            if errors:
+                print('\n'.join(errors), file=sys.stderr)
+            else:
+                r1 = ''
+                r2 = ''
 
-            if pe_count:
-                r1 = r1_reads[0]
-                r2 = r2_reads[0]
+                if pe_count:
+                    r1 = r1_reads[0]
+                    r2 = r2_reads[0]
 
-            if se_reads:
-                r1 = se_reads[0]
-                r2 = EMPTY_FASTQ
+                if se_reads:
+                    r1 = se_reads[0]
+                    r2 = EMPTY_FASTQ
 
-            FOFN.append({
-                'sample': sample, 
-                'titan_wf': args.workflow,
-                'r1': r1,
-                'r2': r2,
-                'primers': get_path(Path(args.primers), abspath, args.prefix)
-            })
+                FOFN.append({
+                    'sample': sample, 
+                    'titan_wf': args.workflow,
+                    'r1': r1,
+                    'r2': r2,
+                    'primers': get_path(Path(args.primers), abspath, args.prefix)
+                })
 
-    if FOFN:
-        if args.tsv:
-            needs_header = True
-            for f in FOFN:
-                if needs_header:
-                    print("\t".join(['sample', 'titan_wf', 'r1', 'r2', 'primers']))
-                    needs_header = False
-                print("\t".join([f['sample'], f['titan_wf'], f['r1'], f['r2'], f['primers']]))
-        else:
-            inputs_json = {
-                "titan_gc.samples": FOFN
-            }
-            params_json = {}
+        if FOFN:
+            if args.tsv:
+                needs_header = True
+                for f in FOFN:
+                    if needs_header:
+                        print("\t".join(['sample', 'titan_wf', 'r1', 'r2', 'primers']))
+                        needs_header = False
+                    print("\t".join([f['sample'], f['titan_wf'], f['r1'], f['r2'], f['primers']]))
+            else:
+                inputs_json = {
+                    "titan_gc.samples": FOFN
+                }
+                params_json = {}
 
 
-            # Add optional parameters if user specified them
-            if args.params:
-                with open(args.params, 'rt') as json_fh:
-                    params_json = json.load(json_fh)
+                # Add optional parameters if user specified them
+                if args.params:
+                    with open(args.params, 'rt') as json_fh:
+                        params_json = json.load(json_fh)
 
-            if args.pangolin_docker:
-                params_json['titan_gc.pangolin_docker_image'] = args.pangolin_docker
-            
-            print(json.dumps({**inputs_json, **params_json}, indent = 4))
+                if args.pangolin_docker:
+                    params_json['titan_gc.pangolin_docker_image'] = args.pangolin_docker
+                
+                print(json.dumps({**inputs_json, **params_json}, indent = 4))
+    else:
+        print(f"Unable to find any FASTQs in {args.path}. Please try adjusting the parameters to fit your needs.", file=sys.stderr)
+        print(f"Values Used:", file=sys.stderr)
+        print(f"    --fastq_pattern => {args.fastq_pattern}", file=sys.stderr)
+        print(f"    --fastq_ext => {args.fastq_ext}", file=sys.stderr)
+        print(f"    --fastq_separator => {args.fastq_separator}", file=sys.stderr)
+        print(f"    --pe1_pattern => {args.pe1_pattern}", file=sys.stderr)
+        print(f"    --pe2_pattern => {args.pe2_pattern}", file=sys.stderr)


### PR DESCRIPTION
Previously, `titan-gc-prepare.py` did not check if the FASTQs directory or the primer BED file existed. These are now checked:

```
bin/titan-gc-prepare.py test-fastqs/ ont does-not-exist.bed
Unable to locate test-fastqs/, please check spelling or verify it exists, and try again
Unable to locate does-not-exist.bed, please check spelling or verify it exists, and try again
```

It also did not say anything if now FASTQs were found:

```
# No FASTQs found, but no message explaining that to the user
bin/titan-gc-prepare.py fastqs/ ont artic-v3.primers.bed --tsv

# Improved method
bin/titan-gc-prepare.py fastqs/ ont artic-v3.primers.bed --tsv
Unable to find any FASTQs in fastqs/. Please try adjusting the parameters to fit your needs.
Values Used:
    --fastq_pattern => *.fastq.gz
    --fastq_ext => .fastq.gz
    --fastq_separator => _
    --pe1_pattern => [Aa]|[Rr]1|1
    --pe2_pattern => [Bb]|[Rr]2|2

```

```
bin/titan-gc-prepare.py fastq/ ont /opt/titan/data/artic-v3.primers.bed --fastq_separator . --tsv | head -n 5
sample  titan_wf        r1      r2      primers
001    ont     /home/robert_petit/fastq/001.fastq.gz    /home/robert_petit/.titan/EMPTY.fastq.gz        /opt/titan/data/artic-v3.primers.bed
002    ont     /home/robert_petit/fastq/002 .fastq.gz    /home/robert_petit/.titan/EMPTY.fastq.gz        /opt/titan/data/artic-v3.primers.bed
003    ont     /home/robert_petit/fastq/003.fastq.gz    /home/robert_petit/.titan/EMPTY.fastq.gz        /opt/titan/data/artic-v3.primers.bed
004    ont     /home/robert_petit/fastq/004.fastq.gz    /home/robert_petit/.titan/EMPTY.fastq.gz        /opt/titan/data/artic-v3.primers.bed
005    ont     /home/robert_petit/fastq/005.fastq.gz    /home/robert_petit/.titan/EMPTY.fastq.gz        /opt/titan/data/artic-v3.primers.bed
```
