### PR TITLE
CLI changes to match bioconda release

### DIFF
--- a/.github/workflows/titan-gc.yml
+++ b/.github/workflows/titan-gc.yml
@@ -29,7 +29,8 @@ jobs:
           conda install -y -c conda-forge -c bioconda cromwell 'python>=3.7' pytest pytest-workflow wget
           chmod 755 bin/*
           cp bin/* ${CONDA_PREFIX}/bin
-          TITAN_VERSION=$(titan-gc-cli --version | sed 's/titan-gc-cli //')
+          TITAN_GC_VERSION=$(grep "PHVG_Version=" tasks/task_versioning.wdl | sed -E 's/.*="PHVG v(.*)"/\1/')
+          export TITAN_GC_VERSION=$(TITAN_GC_VERSION)
           TITAN_SHARE="${CONDA_PREFIX}/share/titan-gc-cli-${TITAN_VERSION}"
           mkdir -p ${TITAN_SHARE}
           mv conf/ tasks/ workflows/ ${TITAN_SHARE}

--- a/.github/workflows/titan-gc.yml
+++ b/.github/workflows/titan-gc.yml
@@ -31,7 +31,7 @@ jobs:
           cp bin/* ${CONDA_PREFIX}/bin
           TITAN_GC_VERSION=$(grep "PHVG_Version=" tasks/task_versioning.wdl | sed -E 's/.*="PHVG v(.*)"/\1/')
           echo "TITAN_GC_VERSION=${TITAN_GC_VERSION}" >> $GITHUB_ENV
-          TITAN_SHARE="${CONDA_PREFIX}/share/titan-gc-cli-${TITAN_GC_VERSION}"
+          TITAN_SHARE="${CONDA_PREFIX}/share/titan-gc-${TITAN_GC_VERSION}"
           mkdir -p ${TITAN_SHARE}
           mv conf/ tasks/ workflows/ ${TITAN_SHARE}
 

--- a/.github/workflows/titan-gc.yml
+++ b/.github/workflows/titan-gc.yml
@@ -30,7 +30,7 @@ jobs:
           chmod 755 bin/*
           cp bin/* ${CONDA_PREFIX}/bin
           TITAN_GC_VERSION=$(grep "PHVG_Version=" tasks/task_versioning.wdl | sed -E 's/.*="PHVG v(.*)"/\1/')
-          export TITAN_GC_VERSION=$(TITAN_GC_VERSION)
+          echo "TITAN_GC_VERSION=${TITAN_GC_VERSION}" >> $GITHUB_ENV
           TITAN_SHARE="${CONDA_PREFIX}/share/titan-gc-cli-${TITAN_GC_VERSION}"
           mkdir -p ${TITAN_SHARE}
           mv conf/ tasks/ workflows/ ${TITAN_SHARE}

--- a/.github/workflows/titan-gc.yml
+++ b/.github/workflows/titan-gc.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: titan-gc-cli
+          activate-environment: titan-gc
           auto-activate-base: false
 
       - name: Setup Titan CI Environment
@@ -36,7 +36,7 @@ jobs:
           mv conf/ tasks/ workflows/ ${TITAN_SHARE}
 
       - name: Environment Information
-        run: uname -a && env && titan-gc-cli -h
+        run: uname -a && env && titan-gc -h
 
       - name: Test Titan-GC Workflows
         run: |

--- a/.github/workflows/titan-gc.yml
+++ b/.github/workflows/titan-gc.yml
@@ -31,7 +31,7 @@ jobs:
           cp bin/* ${CONDA_PREFIX}/bin
           TITAN_GC_VERSION=$(grep "PHVG_Version=" tasks/task_versioning.wdl | sed -E 's/.*="PHVG v(.*)"/\1/')
           export TITAN_GC_VERSION=$(TITAN_GC_VERSION)
-          TITAN_SHARE="${CONDA_PREFIX}/share/titan-gc-cli-${TITAN_VERSION}"
+          TITAN_SHARE="${CONDA_PREFIX}/share/titan-gc-cli-${TITAN_GC_VERSION}"
           mkdir -p ${TITAN_SHARE}
           mv conf/ tasks/ workflows/ ${TITAN_SHARE}
 

--- a/bin/titan-gc
+++ b/bin/titan-gc
@@ -1,7 +1,7 @@
 #! /bin/bash
-# usage: titan-gc-cli [-h] [-i STR] [--inputs STR] [-o STR] [--outdir STR] [--options STR] [--verbose]
+# usage: titan-gc [-h] [-i STR] [--inputs STR] [-o STR] [--outdir STR] [--options STR] [--verbose]
 #
-# titan-gc-cli - Run Titan GC on a set of samples.
+# titan-gc - Run Titan GC on a set of samples.
 #
 # required arguments:
 #   -i STR, --inputs STR  The JSON file to be used with Cromwell for inputs.
@@ -18,22 +18,22 @@ OPTIONS="0"
 QUIET="0"
 PROFILE="docker"
 CONFIG="0"
-TITAN_PATH=$(which titan-gc-cli | sed 's=bin/titan-gc-cli==')
-TITAN_SHARE=${TITAN_PATH}/share/titan-gc-cli-${TITAN_GC_VERSION}
+TITAN_PATH=$(which titan-gc | sed 's=bin/titan-gc==')
+TITAN_SHARE=${TITAN_PATH}/share/titan-gc-${TITAN_GC_VERSION}
 CROMWELL_JAR=$(which cromwell | sed 's=bin/cromwell=share/cromwell/cromwell.jar=')
 LOG_LEVEL=ERROR
 SINGULARITY_CACHE="${HOME}/.singularity/titan-cache"
 CROMWELL_OPTS="${TITAN_SHARE}/conf/options.json"
 
 version() {
-    echo "titan-gc-cli ${TITAN_GC_VERSION}"
+    echo "titan-gc ${TITAN_GC_VERSION}"
     exit 0
 }
 
 usage() {
-    echo "usage: titan-gc-cli [-h] [-i STR] [--inputs STR] [-o STR] [--outdir STR] [--options STR] [--quiet]"
+    echo "usage: titan-gc [-h] [-i STR] [--inputs STR] [-o STR] [--outdir STR] [--options STR] [--quiet]"
     echo ""
-    echo "titan-gc-cli - Run Titan GC on a set of samples."
+    echo "titan-gc - Run Titan GC on a set of samples."
     echo ""
     echo "required arguments:"
     echo "  -i STR, --inputs STR  The JSON file to be used with Cromwell for inputs."

--- a/bin/titan-gc-cli
+++ b/bin/titan-gc-cli
@@ -18,16 +18,15 @@ OPTIONS="0"
 QUIET="0"
 PROFILE="docker"
 CONFIG="0"
-VERSION="1.4.4"
 TITAN_PATH=$(which titan-gc-cli | sed 's=bin/titan-gc-cli==')
-TITAN_SHARE=${TITAN_PATH}/share/titan-gc-cli-${VERSION}
+TITAN_SHARE=${TITAN_PATH}/share/titan-gc-cli-${TITAN_GC_VERSION}
 CROMWELL_JAR=$(which cromwell | sed 's=bin/cromwell=share/cromwell/cromwell.jar=')
 LOG_LEVEL=ERROR
 SINGULARITY_CACHE="${HOME}/.singularity/titan-cache"
 CROMWELL_OPTS="${TITAN_SHARE}/conf/options.json"
 
 version() {
-    echo "titan-gc-cli ${VERSION}"
+    echo "titan-gc-cli ${TITAN_GC_VERSION}"
     exit 0
 }
 

--- a/tests/workflows/titan-gc/test_clearlabs.yml
+++ b/tests/workflows/titan-gc/test_clearlabs.yml
@@ -1,5 +1,5 @@
 - name: titan_clearlabs
-  command: titan-gc-cli -i titan/clearlabs.json -o titan/clearlabs
+  command: titan-gc -i titan/clearlabs.json -o titan/clearlabs
   tags:
     - titan_gc
     - titan_clearlabs

--- a/tests/workflows/titan-gc/test_illumina_pe.yml
+++ b/tests/workflows/titan-gc/test_illumina_pe.yml
@@ -1,5 +1,5 @@
 - name: titan_illumina_pe
-  command: titan-gc-cli -i titan/illumina_pe.json -o titan/illumina_pe
+  command: titan-gc -i titan/illumina_pe.json -o titan/illumina_pe
   tags:
     - titan_gc
     - titan_illumina_pe

--- a/tests/workflows/titan-gc/test_illumina_se.yml
+++ b/tests/workflows/titan-gc/test_illumina_se.yml
@@ -1,5 +1,5 @@
 - name: titan_illumina_se
-  command: titan-gc-cli -i titan/illumina_se.json -o titan/illumina_se
+  command: titan-gc -i titan/illumina_se.json -o titan/illumina_se
   tags:
     - titan_gc
     - titan_illumina_se

--- a/tests/workflows/titan-gc/test_ont.yml
+++ b/tests/workflows/titan-gc/test_ont.yml
@@ -1,5 +1,5 @@
 - name: titan_ont
-  command: titan-gc-cli -i titan/ont.json -o titan/ont
+  command: titan-gc -i titan/ont.json -o titan/ont
   tags:
     - titan_gc
     - titan_ont

--- a/workflows/wf_titan_gc.wdl
+++ b/workflows/wf_titan_gc.wdl
@@ -25,7 +25,7 @@ workflow titan_gc {
 
     input {
         Array[parseJSON] samples
-        String  pangolin_docker_image
+        String  pangolin_docker_image = "staphb/pangolin:3.1.11-pangolearn-2021-08-09"
     }
 
     scatter (sample in samples) {

--- a/workflows/wf_titan_gc.wdl
+++ b/workflows/wf_titan_gc.wdl
@@ -25,7 +25,7 @@ workflow titan_gc {
 
     input {
         Array[parseJSON] samples
-        String  pangolin_docker_image = "staphb/pangolin:3.1.3-pangolearn-2021-06-15"
+        String  pangolin_docker_image
     }
 
     scatter (sample in samples) {


### PR DESCRIPTION
This PR makes some changes to the CLI to reflect the bioconda release.

Main changes

- `titan-gc-cli` renamed to `titan-gc`
- VERSION is retrieved as a environment variable
    - GitHub action uses `tasks_versioning`
    - Bioconda uses the release version
- Updated CI to reflect the change in name