### PR TITLE
Hhalstead nextclade dev

### DIFF
--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -357,6 +357,7 @@ task nextclade_output_parser_one_sample {
       with codecs.open("./input.tsv",'r') as tsv_file:
         tsv_reader=csv.reader(tsv_file, delimiter="\t")
         tsv_data=list(tsv_reader)
+        
         tsv_dict=dict(zip(tsv_data[0], tsv_data[1]))
         with codecs.open ("NEXTCLADE_CLADE", 'wt') as Nextclade_Clade:
           nc_clade=tsv_dict['clade']

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -357,7 +357,8 @@ task nextclade_output_parser_one_sample {
       with codecs.open("./input.tsv",'r') as tsv_file:
         tsv_reader=csv.reader(tsv_file, delimiter="\t")
         tsv_data=list(tsv_reader)
-        
+        if len(tsv_data)==1:
+          tsv_data.append(['NA']*len(tsv_data[0]))
         tsv_dict=dict(zip(tsv_data[0], tsv_data[1]))
         with codecs.open ("NEXTCLADE_CLADE", 'wt') as Nextclade_Clade:
           nc_clade=tsv_dict['clade']


### PR DESCRIPTION
The nextclade_output_parser_one_sample task outputs the following error when consensus sequences are empty:
```
Traceback (most recent call last):
File "<stdin>", line 6, in <module>
IndexError: list index out of range
```
For reference, this is the command section of the nextclade_output_parser_one_sample task until the line that causes the error:
```
# Set WDL input variable to input.tsv file
      cat "~{nextclade_tsv}" > input.tsv
      # Parse outputs using python3
      python3 <<CODE
      import csv
      import codecs
      with codecs.open("./input.tsv",'r') as tsv_file:
        tsv_reader=csv.reader(tsv_file, delimiter="\t")
        tsv_data=list(tsv_reader)
        tsv_dict=dict(zip(tsv_data[0], tsv_data[1]))
```
When the consensus sequence used to generate nextclade_tsv is truly empty of any sequence (not even N's) the nextclade_tsv file only has column headers. When the consensus sequence has some amount of N's, there is a comment that is output into one of the columns of the nextclade_tsv, and ID is added, and the rest of the columns are NULL. Because the nextclade_tsv file generated from the empty consensus sequence has only headers, line 6 of the python section (tsv_dict=dict(zip(tsv_data[0], tsv_data[1]))) throws an error and stops the pipeline because because tsv_data[1] does not exist. To get around this issue I changed the above section to this:
```
# Set WDL input variable to input.tsv file
      cat "~{nextclade_tsv}" > input.tsv
      # Parse outputs using python3
      python3 <<CODE
      import csv
      import codecs
      with codecs.open("./input.tsv",'r') as tsv_file:
        tsv_reader=csv.reader(tsv_file, delimiter="\t")
        tsv_data=list(tsv_reader)
        if len(tsv_data)==1:
          tsv_data.append(['NA']*len(tsv_data[0]))
        tsv_dict=dict(zip(tsv_data[0], tsv_data[1]))
```
Another words, adding this after line 359 in the task_taxonID.wdl script:
```
if len(tsv_data)==1:
        tsv_data.append(['NA']*len(tsv_data[0]))
```