### PR TITLE
Remove only leading Ns

### DIFF
--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -82,7 +82,7 @@ task ncbi_prep_one_sample {
     ##GenBank assembly
     ###removing leading Ns, folding sequencing to 75 bp wide, and adding metadata for genbank submissions
     echo ">"~{submission_id} > ~{submission_id}_genbank.fasta
-    grep -v ">" ~{assembly_fasta} | sed 's/^N*N//g' | fold -w 75 >> ~{submission_id}_genbank.fasta
+    grep -v ">" ~{assembly_fasta} | sed '2 's/^N*N//g'' | fold -w 75 >> ~{submission_id}_genbank.fasta
     
     ##GenBank modifier
     echo -e "Sequence_ID\tcountry\thost\tisolate\tcollection-date\tisolation-source\tBioSample\tBioProject\tnote" > ~{submission_id}_genbank_modifier.tsv

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -189,7 +189,7 @@ task ncbi_prep_one_sample_se {
     ##GenBank assembly
     ###removing leading Ns, folding sequencing to 75 bp wide, and adding metadata for genbank submissions
     echo ">"~{submission_id} > ~{submission_id}_genbank.fasta
-    grep -v ">" ~{assembly_fasta} | sed '2 ''s/^N*N//g'' | fold -w 75 >> ~{submission_id}_genbank.fasta
+    grep -v ">" ~{assembly_fasta} | sed '2 's/^N*N//g'' | fold -w 75 >> ~{submission_id}_genbank.fasta
     
     ##GenBank modifier
     echo -e "Sequence_ID\tcountry\thost\tisolate\tcollection-date\tisolation-source\tBioSample\tBioProject\tnote" > ~{submission_id}_genbank_modifier.tsv

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -82,7 +82,7 @@ task ncbi_prep_one_sample {
     ##GenBank assembly
     ###removing leading Ns, folding sequencing to 75 bp wide, and adding metadata for genbank submissions
     echo ">"~{submission_id} > ~{submission_id}_genbank.fasta
-    grep -v ">" ~{assembly_fasta} | sed '2 's/^N*N//g'' | fold -w 75 >> ~{submission_id}_genbank.fasta
+    grep -v ">" ~{assembly_fasta} | sed '1 's/^N*N//g'' | fold -w 75 >> ~{submission_id}_genbank.fasta
     
     ##GenBank modifier
     echo -e "Sequence_ID\tcountry\thost\tisolate\tcollection-date\tisolation-source\tBioSample\tBioProject\tnote" > ~{submission_id}_genbank_modifier.tsv
@@ -189,7 +189,7 @@ task ncbi_prep_one_sample_se {
     ##GenBank assembly
     ###removing leading Ns, folding sequencing to 75 bp wide, and adding metadata for genbank submissions
     echo ">"~{submission_id} > ~{submission_id}_genbank.fasta
-    grep -v ">" ~{assembly_fasta} | sed '2 's/^N*N//g'' | fold -w 75 >> ~{submission_id}_genbank.fasta
+    grep -v ">" ~{assembly_fasta} | sed '1 's/^N*N//g'' | fold -w 75 >> ~{submission_id}_genbank.fasta
     
     ##GenBank modifier
     echo -e "Sequence_ID\tcountry\thost\tisolate\tcollection-date\tisolation-source\tBioSample\tBioProject\tnote" > ~{submission_id}_genbank_modifier.tsv

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -189,7 +189,7 @@ task ncbi_prep_one_sample_se {
     ##GenBank assembly
     ###removing leading Ns, folding sequencing to 75 bp wide, and adding metadata for genbank submissions
     echo ">"~{submission_id} > ~{submission_id}_genbank.fasta
-    grep -v ">" ~{assembly_fasta} | sed 's/^N*N//g' | fold -w 75 >> ~{submission_id}_genbank.fasta
+    grep -v ">" ~{assembly_fasta} | sed '2 ''s/^N*N//g'' | fold -w 75 >> ~{submission_id}_genbank.fasta
     
     ##GenBank modifier
     echo -e "Sequence_ID\tcountry\thost\tisolate\tcollection-date\tisolation-source\tBioSample\tBioProject\tnote" > ~{submission_id}_genbank_modifier.tsv


### PR DESCRIPTION
This PR addresses the issue of GenBank-formatted samples raising VADR alerts not identified in the original assemblies: multi-line fasta files were susceptible to inadvertent removal of internal Ns leading to downstream annotation issues with VADR. 
 
This issue was resolved by restricting the `sed` replacement command to only the first line of nucleotide data.
 
v1.5.2: `sed 's/^N*N//g'`
PR: `sed '1 's/^N*N//g''`

This PR will resolve this issue for both `Mercury_SE_Prep` and `Mercury_PE_Prep`