### PR TITLE
Cjk quay migration

### DIFF
--- a/tasks/task_alignment.wdl
+++ b/tasks/task_alignment.wdl
@@ -35,7 +35,7 @@ task bwa {
   }
 
   runtime {
-    docker:       "staphb/ivar:1.3.1-titan"
+    docker:       "quay.io/staphb/ivar:1.3.1-titan"
     memory:       "8 GB"
     cpu:          2
     disks:        "local-disk 100 SSD"
@@ -68,7 +68,7 @@ task mafft {
   }
 
   runtime {
-    docker:       "staphb/mafft:7.450"
+    docker:       "quay.io/staphb/mafft:7.450"
     memory:       "32 GB"
     cpu:          16
     disks:        "local-disk 100 SSD"

--- a/tasks/task_assembly_metrics.wdl
+++ b/tasks/task_assembly_metrics.wdl
@@ -47,7 +47,7 @@ task stats_n_coverage {
   }
 
   runtime {
-    docker:       "staphb/samtools:1.10"
+    docker:       "quay.io/staphb/samtools:1.10"
     memory:       "8 GB"
     cpu:          2
     disks:        "local-disk 100 SSD"

--- a/tasks/task_consensus_call.wdl
+++ b/tasks/task_consensus_call.wdl
@@ -48,7 +48,7 @@ task primer_trim {
   }
 
   runtime {
-    docker:       "staphb/ivar:1.3.1-titan"
+    docker:       "quay.io/staphb/ivar:1.3.1-titan"
     memory:       "8 GB"
     cpu:          2
     disks:        "local-disk 100 SSD"
@@ -113,7 +113,7 @@ task variant_call {
   }
 
   runtime {
-    docker:       "staphb/ivar:1.3.1-titan"
+    docker:       "quay.io/staphb/ivar:1.3.1-titan"
     memory:       "8 GB"
     cpu:          2
     disks:        "local-disk 100 SSD"
@@ -173,7 +173,7 @@ task consensus {
   }
 
   runtime {
-    docker:       "staphb/ivar:1.3.1-titan"
+    docker:       "quay.io/staphb/ivar:1.3.1-titan"
     memory:       "8 GB"
     cpu:          2
     disks:        "local-disk 100 SSD"

--- a/tasks/task_data_vis.wdl
+++ b/tasks/task_data_vis.wdl
@@ -54,7 +54,7 @@ task cluster_render {
   }
 
   runtime {
-    docker:       "theiagen/cluster-report-env:1.2"
+    docker:       "quay.io/theiagen/cluster-report-env:1.2"
     memory:       "2 GB"
     cpu:          2
     disks:        "local-disk 100 SSD"

--- a/tasks/task_ncbi.wdl
+++ b/tasks/task_ncbi.wdl
@@ -10,7 +10,7 @@ task vadr {
     Int assembly_length_unambiguous
     Int skip_length=10000
 
-    String  docker="staphb/vadr:1.3"
+    String  docker="quay.io/staphb/vadr:1.3"
     Int minlen=50
     Int maxlen=30000
   }

--- a/tasks/task_nextclade_output_parser.wdl
+++ b/tasks/task_nextclade_output_parser.wdl
@@ -6,7 +6,7 @@ task nextclade_output_parser_one_sample {
     }
     input {
         File   nextclade_tsv
-        String docker = "theiagen/utility:1.1"
+        String docker = "quay.io/theiagen/utility:1.1"
     }
     command {
       python3 <<CODE

--- a/tasks/task_ont_medaka.wdl
+++ b/tasks/task_ont_medaka.wdl
@@ -55,7 +55,7 @@ task read_filtering {
 
   runtime {
 
-    docker:       "staphb/artic-ncov2019:1.3.0"
+    docker:       "quay.io/staphb/artic-ncov2019:1.3.0"
     memory:       "16 GB"
     cpu:          8
     disks:        "local-disk 100 SSD"
@@ -73,7 +73,7 @@ task consensus {
     Int?    normalise=20000
     Int?    cpu=8
     String  medaka_model="r941_min_high_g360"
-    String  docker="staphb/artic-ncov2019:1.3.0"
+    String  docker="quay.io/staphb/artic-ncov2019:1.3.0"
   }
   String primer_name = basename(primer_bed)
   

--- a/tasks/task_pe_pub_repo_submission.wdl
+++ b/tasks/task_pe_pub_repo_submission.wdl
@@ -7,7 +7,7 @@ task deidentify {
     String    submission_id
     File      sequence
 
-    String    docker_image = "staphb/seqyclean:1.10.09"
+    String    docker_image = "quay.io/staphb/seqyclean:1.10.09"
     Int       mem_size_gb = 3
     Int       CPUs = 1
     Int       disk_size = 100
@@ -80,7 +80,7 @@ task gisaid {
     String    treatment=""
     String    iso_county = ""
 
-    String    docker_image = "staphb/seqyclean:1.10.09"
+    String    docker_image = "quay.io/staphb/seqyclean:1.10.09"
     Int       mem_size_gb = 3
     Int       CPUs = 1
     Int       disk_size = 10
@@ -131,7 +131,7 @@ task genbank {
     String    specimen_source
     String    BioProject
 
-    String    docker_image = "theiagen/utility:1.1"
+    String    docker_image = "quay.io/theiagen/utility:1.1"
     Int       mem_size_gb = 3
     Int       CPUs = 1
     Int       disk_size = 10
@@ -174,7 +174,7 @@ task sra {
     File      read1
     File?     read2
 
-    String    docker_image = "staphb/seqyclean:1.10.09"
+    String    docker_image = "quay.io/staphb/seqyclean:1.10.09"
     Int       mem_size_gb = 1
     Int       CPUs = 1
     Int       disk_size = 25
@@ -214,7 +214,7 @@ input {
   Array[Int]  vadr_num_alerts
   Int         vadr_threshold=0
   String      repository
-  String      docker_image = "theiagen/utility:1.1"
+  String      docker_image = "quay.io/theiagen/utility:1.1"
   Int         mem_size_gb = 1
   Int         CPUs = 1
   Int         disk_size = 25

--- a/tasks/task_phylo.wdl
+++ b/tasks/task_phylo.wdl
@@ -23,7 +23,7 @@ task snp_dists {
   }
 
   runtime {
-    docker:       "staphb/snp-dists:0.6.2"
+    docker:       "quay.io/staphb/snp-dists:0.6.2"
     memory:       "2 GB"
     cpu:          2
     disks:        "local-disk 100 SSD"
@@ -62,7 +62,7 @@ task iqtree {
   }
 
   runtime {
-    docker:       "staphb/iqtree:1.6.7"
+    docker:       "quay.io/staphb/iqtree:1.6.7"
     memory:       "8 GB"
     cpu:          4
     disks:        "local-disk 100 SSD"

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -49,7 +49,7 @@ task ncbi_prep_one_sample {
     Int maxlen = 30000
     
     #runtime
-    String docker_image = "staphb/vadr:1.3"
+    String docker_image = "quay.io/staphb/vadr:1.3"
     Int  mem_size_gb = 1
     Int CPUs = 1
     Int disk_size = 25
@@ -168,7 +168,7 @@ task ncbi_prep_one_sample_se {
     Int maxlen = 30000
     
     #runtime
-    String docker_image = "staphb/vadr:1.3"
+    String docker_image = "quay.io/staphb/vadr:1.3"
     Int  mem_size_gb = 1
     Int CPUs = 1
     Int disk_size = 25
@@ -273,7 +273,7 @@ task gisaid_prep_one_sample {
     String? treatment
     
     #runtime
-    String docker_image = "theiagen/utility:1.1"
+    String docker_image = "quay.io/theiagen/utility:1.1"
     Int  mem_size_gb = 1
     Int CPUs = 1
     Int disk_size = 25
@@ -332,7 +332,7 @@ task compile_assembly_n_meta {
     String repository
     String file_ext
     String date
-    String docker_image = "theiagen/utility:1.1"
+    String docker_image = "quay.io/theiagen/utility:1.1"
     Int mem_size_gb = 8
     Int CPUs = 4
     Int disk_size = 100
@@ -447,7 +447,7 @@ input {
   String date
   String? gcp_bucket
 
-  String      docker_image = "theiagen/utility:1.1"
+  String      docker_image = "quay.io/theiagen/utility:1.1"
   Int         mem_size_gb = 16
   Int         CPUs = 4
   Int         disk_size = 100

--- a/tasks/task_qc_utils.wdl
+++ b/tasks/task_qc_utils.wdl
@@ -44,7 +44,7 @@ task fastqc {
   }
 
   runtime {
-    docker:       "staphb/fastqc:0.11.8"
+    docker:       "quay.io/staphb/fastqc:0.11.9"
     memory:       "4 GB"
     cpu:          2
     disks:        "local-disk 100 SSD"
@@ -83,7 +83,7 @@ task fastqc_se {
   }
 
   runtime {
-    docker:       "staphb/fastqc:0.11.8"
+    docker:       "quay.io/staphb/fastqc:0.11.8"
     memory:       "4 GB"
     cpu:          2
     disks:        "local-disk 100 SSD"
@@ -131,7 +131,7 @@ task consensus_qc {
   }
 
   runtime {
-    docker:       "theiagen/utility:1.1"    
+    docker:       "quay.io/theiagen/utility:1.1"    
     memory:       "2 GB"
     cpu:          1
     disks:        "local-disk 100 SSD"


### PR DESCRIPTION
The great quay migration. Updated all tasks with quay-hosted docker images, where available.

Some other small changes:
  * made default pangolin container 3.1.14-pangolearn-2021-10-13 since 3.1.1 does not have `pangolin --all-versions` option, leading to blank output columns for `pango_versions`
  * harmonized ncbi_scrub tasks to both use GCR-hosted docker image
  * upgraded fastqc to 0.11.9 in an attempt to resolve rare OOM errors

Still need to test (this will take a lot of different workflows), but should be a pretty seamless transition