### PR TITLE
SRA read prep Input as string array

### DIFF
--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -491,7 +491,7 @@ input {
   then 
     echo "Moving read data to provided GCP Bucket ~{gcp_bucket}"
     echo "Running: gsutil -m cp -n ${sra_reads_array[*]} ~{gcp_bucket}"
-    Running: gsutil -m cp -n ${sra_reads_array} ~{gcp_bucket}       
+    Running: gsutil -m cp -n ${sra_reads_array[@]} ~{gcp_sbucket}       
   else 
     echo "Preparing SRA read data into single zipped-file"
     mkdir sra_reads_~{date} 

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -459,7 +459,7 @@ input {
   biosample_attributes_array_len=$(echo "${#biosample_attributes_array[@]}")
   sra_metadata_array=(~{sep=' ' single_submission_sra_metadata})
   sra_metadata_array_len=$(echo "${#sra_metadata_array[@]}")
-  sra_reads_array=~{sep=' ' single_submission_sra_reads}
+  sra_reads_array="~{sep=' ' single_submission_sra_reads}"
   sra_reads_arra_len=$(echo "${#sra_reads_arra[@]}")
   
   # Compile BioSample attributes

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -491,7 +491,7 @@ input {
   then 
     echo "Moving read data to provided GCP Bucket ~{gcp_bucket}"
     echo "Running: gsutil -m cp -n ${sra_reads_array[*]} ~{gcp_bucket}"
-    Running: gsutil -m cp -n ${sra_reads_array[*]} ~{gcp_bucket}       
+    Running: gsutil -m cp -n ${sra_reads_array} ~{gcp_bucket}       
   else 
     echo "Preparing SRA read data into single zipped-file"
     mkdir sra_reads_~{date} 

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -459,7 +459,7 @@ input {
   biosample_attributes_array_len=$(echo "${#biosample_attributes_array[@]}")
   sra_metadata_array=(~{sep=' ' single_submission_sra_metadata})
   sra_metadata_array_len=$(echo "${#sra_metadata_array[@]}")
-  sra_reads_array=(~{sep=' ' single_submission_sra_reads})
+  sra_reads_array=~{sep=' ' single_submission_sra_reads}
   sra_reads_arra_len=$(echo "${#sra_reads_arra[@]}")
   
   # Compile BioSample attributes
@@ -490,9 +490,8 @@ input {
   if [[ ! -z "~{gcp_bucket}" ]]
   then 
     echo "Moving read data to provided GCP Bucket ~{gcp_bucket}"
-    for i in ${sra_reads_array[*]}; do
-      gsutil -m cp -n $i ~{gcp_bucket}
-    done  
+    echo "Running: gsutil -m cp -n ${sra_reads_array[*]} ~{gcp_bucket}"
+    Running: gsutil -m cp -n ${sra_reads_array[*]} ~{gcp_bucket}       
   else 
     echo "Preparing SRA read data into single zipped-file"
     mkdir sra_reads_~{date} 

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -443,7 +443,7 @@ task compile_biosamp_n_sra {
 input {
   Array[File] single_submission_biosample_attirbutes
   Array[File] single_submission_sra_metadata
-  Array[File] single_submission_sra_reads
+  Array[String] single_submission_sra_reads
   String date
   String? gcp_bucket
 

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -490,8 +490,8 @@ input {
   if [[ ! -z "~{gcp_bucket}" ]]
   then 
     echo "Moving read data to provided GCP Bucket ~{gcp_bucket}"
-    echo "Running: gsutil -m cp -n ${sra_reads_array[*]} ~{gcp_bucket}"
-    Running: gsutil -m cp -n ${sra_reads_array[@]} ~{gcp_bucket}       
+    echo "Running: gsutil -m cp -n ${sra_reads_array[@]} ~{gcp_bucket}"
+    gsutil -m cp -n ${sra_reads_array[@]} ~{gcp_bucket}       
   else 
     echo "Preparing SRA read data into single zipped-file"
     mkdir sra_reads_~{date} 

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -491,7 +491,7 @@ input {
   then 
     echo "Moving read data to provided GCP Bucket ~{gcp_bucket}"
     echo "Running: gsutil -m cp -n ${sra_reads_array[*]} ~{gcp_bucket}"
-    Running: gsutil -m cp -n ${sra_reads_array[@]} ~{gcp_sbucket}       
+    Running: gsutil -m cp -n ${sra_reads_array[@]} ~{gcp_bucket}       
   else 
     echo "Preparing SRA read data into single zipped-file"
     mkdir sra_reads_~{date} 

--- a/workflows/wf_mercury_batch.wdl
+++ b/workflows/wf_mercury_batch.wdl
@@ -10,7 +10,7 @@ workflow mercury_batch {
     Array[File] gisaid_assembly
     Array[File] gisaid_metadata
     Array[File] sra_metadata
-    Array[File] sra_reads
+    Array[String] sra_reads
     Array[File] biosample_attributes
     Array[String] samplename
     Array[String] submission_id


### PR DESCRIPTION
This PR converts the `single_submission_sra_reads` input attribute of the `compile_biosamp_n_sra` task from a `Array[File]` to `Array[String]`. This modification allows for quicker transfer of read data to the SRA transfer bucket as localization is no longer required, but will drop the functionality of preparing a zipped file of reads for the user. If a SRA transfer bucket is not defined, the user will need to download the read files locally and upload them through the NCBI portal for submission. 