### PR TITLE
Percent gene coverage calculations

### DIFF
--- a/tasks/task_assembly_metrics.wdl
+++ b/tasks/task_assembly_metrics.wdl
@@ -54,7 +54,8 @@ task stats_n_coverage {
     ngene_pc=$(python3 -c "print ( round( ($ngene / 1260 ) * 100, 2 ) )")
     orf10_pc=$(python3 -c "print ( round( ($orf6 / 117 ) * 100, 2 ) )")
 
-    echo -e "Gene\tPercent_Coverage" > ~{samplename}.percent_gene_coverage.tsv
+    echo -e "#NOTE: THE VALUES BELOW ASSUME WUHAN-1 REFERENCE GENOME" > ~{samplename}.percent_gene_coverage.tsv
+    echo -e "Gene\tPercent_Coverage" >> ~{samplename}.percent_gene_coverage.tsv
     echo -e "ORF1ab\t" $orf1ab_pc >> ~{samplename}.percent_gene_coverage.tsv
     echo -e "S_gene\t" $sgene_pc >> ~{samplename}.percent_gene_coverage.tsv
     echo -e "ORF3a\t" $orf3a_pc >> ~{samplename}.percent_gene_coverage.tsv

--- a/tasks/task_assembly_metrics.wdl
+++ b/tasks/task_assembly_metrics.wdl
@@ -38,9 +38,9 @@ task stats_n_coverage {
     orf6=$(samtools depth -J -r "${chr}:27202-27387" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
     orf7a=$(samtools depth -J -r "${chr}:27394-27759" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
     orf7b=$(samtools depth -J -r "${chr}:27756-27887" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
-		orf8=$(samtools depth -J -r "${chr}:27894-28259" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+    orf8=$(samtools depth -J -r "${chr}:27894-28259" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
     ngene=$(samtools depth -J -r "${chr}:28274-29533" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
-		orf10=$(samtools depth -J -r "${chr}:29558-29674" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+    orf10=$(samtools depth -J -r "${chr}:29558-29674" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
 
     orf1ab_pc=$(python3 -c "print ( round( ($orf1ab / 21290 ) * 100, 2 ) )")
     sgene_pc=$(python3 -c "print ( round( ($sgene / 3822 ) * 100, 2 ) )")

--- a/tasks/task_assembly_metrics.wdl
+++ b/tasks/task_assembly_metrics.wdl
@@ -30,7 +30,7 @@ task stats_n_coverage {
 
     # samtools outputs 3 columns; column 3 is the depth of coverage per nucleotide position, piped to awk to count the positions
     #  above min_depth, then wc -l counts them all
-    orf1ab=$(samtools depth -J -r "${chr}:21563-25384" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+    orf1ab=$(samtools depth -J -r "${chr}:266-21555" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
     sgene=$(samtools depth -J -r "${chr}:~{s_gene_start}-~{s_gene_stop}" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
     orf3a=$(samtools depth -J -r "${chr}:25393-26220" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
     egene=$(samtools depth -J -r "${chr}:26245-26472" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
@@ -48,11 +48,11 @@ task stats_n_coverage {
     egene_pc=$(python3 -c "print ( round( ($egene / 228 ) * 100, 2 ) )")
     mgene_pc=$(python3 -c "print ( round( ($mgene / 669 ) * 100, 2 ) )")
     orf6_pc=$(python3 -c "print ( round( ($orf6 / 186 ) * 100, 2 ) )")
-    orf7a_pc=$(python3 -c "print ( round( ($orf7a / 266 ) * 100, 2 ) )")
+    orf7a_pc=$(python3 -c "print ( round( ($orf7a / 366 ) * 100, 2 ) )")
     orf7b_pc=$(python3 -c "print ( round( ($orf7b / 132 ) * 100, 2 ) )")
     orf8_pc=$(python3 -c "print ( round( ($orf8 / 366 ) * 100, 2 ) )")
     ngene_pc=$(python3 -c "print ( round( ($ngene / 1260 ) * 100, 2 ) )")
-    orf10_pc=$(python3 -c "print ( round( ($orf6 / 117 ) * 100, 2 ) )")
+    orf10_pc=$(python3 -c "print ( round( ($orf10 / 117 ) * 100, 2 ) )")
 
     echo -e "#NOTE: THE VALUES BELOW ASSUME WUHAN-1 REFERENCE GENOME" > ~{samplename}.percent_gene_coverage.tsv
     echo -e "Gene\tPercent_Coverage" >> ~{samplename}.percent_gene_coverage.tsv

--- a/tasks/task_assembly_metrics.wdl
+++ b/tasks/task_assembly_metrics.wdl
@@ -30,7 +30,7 @@ task stats_n_coverage {
 
     # samtools outputs 3 columns; column 3 is the depth of coverage per nucleotide position, piped to awk to count the positions
     #  above min_depth, then wc -l counts them all
-    orf1ab=$(samtools depth -J -r "${chr}:21563-25384" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth} print;}' | wc -l )
+    orf1ab=$(samtools depth -J -r "${chr}:21563-25384" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
     sgene=$(samtools depth -J -r "${chr}:~{s_gene_start}-~{s_gene_stop}" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
     orf3a=$(samtools depth -J -r "${chr}:25393-26220" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
     egene=$(samtools depth -J -r "${chr}:26245-26472" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )

--- a/tasks/task_assembly_metrics.wdl
+++ b/tasks/task_assembly_metrics.wdl
@@ -97,7 +97,7 @@ task stats_n_coverage {
     Float meanmapq = read_string("MEANMAPQ")
   }
   runtime {
-    docker: "quay.io/staphb/samtools:1.10"
+    docker: "quay.io/staphb/samtools:1.14"
     memory: "8 GB"
     cpu: 2
     disks: "local-disk 100 SSD"

--- a/tasks/task_assembly_metrics.wdl
+++ b/tasks/task_assembly_metrics.wdl
@@ -6,6 +6,7 @@ task stats_n_coverage {
     String samplename
     Int s_gene_start = 21563
     Int s_gene_stop = 25384
+    Int? min_depth
   }
   command <<<
     date | tee DATE
@@ -27,6 +28,46 @@ task stats_n_coverage {
     samtools coverage -r "${chr}:~{s_gene_start}-~{s_gene_stop}" ~{bamfile} >> ~{samplename}.cov.txt
     s_gene_depth=$(cut -f 7 ~{samplename}.cov.txt | tail -n 1)
 
+    # samtools outputs 3 columns; column 3 is the depth of coverage per nucleotide position, piped to awk to count the positions
+    #  above min_depth, then wc -l counts them all
+    orf1ab=$(samtools depth -J -r "${chr}:21563-25384" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth} print;}' | wc -l )
+    sgene=$(samtools depth -J -r "${chr}:~{s_gene_start}-~{s_gene_stop}" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+    orf3a=$(samtools depth -J -r "${chr}:25393-26220" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+    egene=$(samtools depth -J -r "${chr}:26245-26472" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+    mgene=$(samtools depth -J -r "${chr}:26523-27191" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+    orf6=$(samtools depth -J -r "${chr}:27202-27387" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+    orf7a=$(samtools depth -J -r "${chr}:27394-27759" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+    orf7b=$(samtools depth -J -r "${chr}:27756-27887" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+		orf8=$(samtools depth -J -r "${chr}:27894-28259" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+    ngene=$(samtools depth -J -r "${chr}:28274-29533" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+		orf10=$(samtools depth -J -r "${chr}:29558-29674" ~{bamfile} | awk -F "\t" '{if ($3 > ~{min_depth}) print;}' | wc -l )
+
+    orf1ab_pc=$(python3 -c "print ( round( ($orf1ab / 21290 ) * 100, 2 ) )")
+    sgene_pc=$(python3 -c "print ( round( ($sgene / 3822 ) * 100, 2 ) )")
+    orf3a_pc=$(python3 -c "print ( round( ($orf3a / 828 ) * 100, 2 ) )")
+    egene_pc=$(python3 -c "print ( round( ($egene / 228 ) * 100, 2 ) )")
+    mgene_pc=$(python3 -c "print ( round( ($mgene / 669 ) * 100, 2 ) )")
+    orf6_pc=$(python3 -c "print ( round( ($orf6 / 186 ) * 100, 2 ) )")
+    orf7a_pc=$(python3 -c "print ( round( ($orf7a / 266 ) * 100, 2 ) )")
+    orf7b_pc=$(python3 -c "print ( round( ($orf7b / 132 ) * 100, 2 ) )")
+    orf8_pc=$(python3 -c "print ( round( ($orf8 / 366 ) * 100, 2 ) )")
+    ngene_pc=$(python3 -c "print ( round( ($ngene / 1260 ) * 100, 2 ) )")
+    orf10_pc=$(python3 -c "print ( round( ($orf6 / 117 ) * 100, 2 ) )")
+
+    echo -e "Gene\tPercent_Coverage" > ~{samplename}.percent_gene_coverage.tsv
+    echo -e "ORF1ab\t" $orf1ab_pc >> ~{samplename}.percent_gene_coverage.tsv
+    echo -e "S_gene\t" $sgene_pc >> ~{samplename}.percent_gene_coverage.tsv
+    echo -e "ORF3a\t" $orf3a_pc >> ~{samplename}.percent_gene_coverage.tsv
+    echo -e "E_gene\t" $egene_pc >> ~{samplename}.percent_gene_coverage.tsv
+    echo -e "M_gene\t" $mgene_pc >> ~{samplename}.percent_gene_coverage.tsv
+    echo -e "ORF6\t" $orf6_pc >> ~{samplename}.percent_gene_coverage.tsv
+    echo -e "ORF7a\t" $orf7a_pc >> ~{samplename}.percent_gene_coverage.tsv
+    echo -e "ORF7b\t" $orf7b_pc >> ~{samplename}.percent_gene_coverage.tsv
+    echo -e "ORF8\t" $orf8_pc >> ~{samplename}.percent_gene_coverage.tsv
+    echo -e "N_gene\t" $ngene_pc >> ~{samplename}.percent_gene_coverage.tsv
+    echo -e "ORF10\t" $orf10_pc >> ~{samplename}.percent_gene_coverage.tsv
+
+
     if [ -z "$coverage" ] ; then coverage="0" ; fi
     if [ -z "s_gene_depth" ] ; then s_gene_depth="0"; fi
     if [ -z "$depth" ] ; then depth="0" ; fi
@@ -36,6 +77,7 @@ task stats_n_coverage {
     echo $coverage | tee COVERAGE
     echo $depth | tee DEPTH
     echo $s_gene_depth | tee S_GENE_DEPTH
+    echo $sgene_pc | tee S_GENE_PC
     echo $meanbaseq | tee MEANBASEQ
     echo $meanmapq | tee MEANMAPQ
   >>>
@@ -49,6 +91,8 @@ task stats_n_coverage {
     Float coverage = read_string("COVERAGE")
     Float depth = read_string("DEPTH")
     Float s_gene_depth = read_string("S_GENE_DEPTH")
+    Float s_gene_percent_coverage = read_string("S_GENE_PC")
+    File percent_gene_coverage = "~{samplename}.percent_gene_coverage.tsv"
     Float meanbaseq = read_string("MEANBASEQ")
     Float meanmapq = read_string("MEANMAPQ")
   }

--- a/tasks/task_assembly_metrics.wdl
+++ b/tasks/task_assembly_metrics.wdl
@@ -98,7 +98,7 @@ task stats_n_coverage {
     Float meanmapq = read_string("MEANMAPQ")
   }
   runtime {
-    docker: "quay.io/staphb/samtools:1.14"
+    docker: "quay.io/staphb/samtools:1.15"
     memory: "8 GB"
     cpu: 2
     disks: "local-disk 100 SSD"

--- a/tasks/task_consensus_call.wdl
+++ b/tasks/task_consensus_call.wdl
@@ -65,7 +65,7 @@ task variant_call {
     Int? min_bq = "0"
     Int? min_qual = "20"
     Float? min_freq = "0.6"
-    Int? min_depth = "100"
+    Int? variant_min_depth 
   }
   command <<<
     # date and version control
@@ -104,7 +104,7 @@ task variant_call {
     -p ~{samplename}.variants \
     -q ~{min_qual} \
     -t ~{min_freq} \
-    -m ~{min_depth} \
+    -m ~{variant_min_depth} \
     -r ${ref_genome} \
     -g ${ref_gff}
 
@@ -144,7 +144,7 @@ task consensus {
     Int? min_bq = "0"
     Int? min_qual = "20"
     Float? min_freq = "0.6"
-    Int? min_depth = "100"
+    Int? consensus_min_depth
     String? char_unknown = "N"
   }
   command <<<
@@ -175,7 +175,7 @@ task consensus {
     -p ~{samplename}.consensus \
     -q ~{min_qual} \
     -t ~{min_freq} \
-    -m ~{min_depth} \
+    -m ~{consensus_min_depth} \
     -n ~{char_unknown}
 
     # clean up fasta header

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -23,6 +23,7 @@ workflow theiacov_illumina_pe {
     String nextclade_dataset_reference = "MN908947"
     String nextclade_dataset_tag = "2022-02-07T12:00:00Z"
     File? reference_genome
+    Int? min_depth = "100"
   }
   call read_qc.read_QC_trim {
     input:
@@ -42,18 +43,22 @@ workflow theiacov_illumina_pe {
       samplename = samplename,
       primer_bed = primer_bed,
       bamfile = bwa.sorted_bam
+      
   }
   call consensus_call.variant_call {
     input:
       samplename = samplename,
       bamfile = primer_trim.trim_sorted_bam,
-      reference_genome = reference_genome
+      reference_genome = reference_genome,
+      variant_min_depth = min_depth
   }
   call consensus_call.consensus {
     input:
       samplename = samplename,
       bamfile = primer_trim.trim_sorted_bam,
-      reference_genome = reference_genome
+      reference_genome = reference_genome,
+      consensus_min_depth = min_depth
+
   }
   call qc_utils.consensus_qc {
     input:

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -43,7 +43,6 @@ workflow theiacov_illumina_pe {
       samplename = samplename,
       primer_bed = primer_bed,
       bamfile = bwa.sorted_bam
-      
   }
   call consensus_call.variant_call {
     input:
@@ -58,7 +57,6 @@ workflow theiacov_illumina_pe {
       bamfile = primer_trim.trim_sorted_bam,
       reference_genome = reference_genome,
       consensus_min_depth = min_depth
-
   }
   call qc_utils.consensus_qc {
     input:
@@ -67,7 +65,8 @@ workflow theiacov_illumina_pe {
   call assembly_metrics.stats_n_coverage {
     input:
       samplename = samplename,
-      bamfile = bwa.sorted_bam
+      bamfile = bwa.sorted_bam,
+      min_depth = min_depth
   }
   call assembly_metrics.stats_n_coverage as stats_n_coverage_primtrim {
     input:
@@ -154,6 +153,8 @@ workflow theiacov_illumina_pe {
     Float meanmapq_trim = stats_n_coverage_primtrim.meanmapq
     Float assembly_mean_coverage = stats_n_coverage_primtrim.depth
     Float s_gene_mean_coverage = stats_n_coverage_primtrim.s_gene_depth
+    Float s_gene_percent_coverage = stats_n_coverage_primtrim.s_gene_percent_coverage
+    File percent_gene_coverage = stats_n_coverage_primtrim.percent_gene_coverage
     String samtools_version_stats = stats_n_coverage.samtools_version
     # Lineage Assignment
     String pango_lineage = pangolin3.pangolin_lineage

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -71,7 +71,8 @@ workflow theiacov_illumina_pe {
   call assembly_metrics.stats_n_coverage as stats_n_coverage_primtrim {
     input:
       samplename = samplename,
-      bamfile = primer_trim.trim_sorted_bam
+      bamfile = primer_trim.trim_sorted_bam,
+      min_depth = min_depth
   }
   call taxon_ID.pangolin3 {
     input:


### PR DESCRIPTION
This PR consolidates the various min_depth input variables into one, implements some arithmetic to calculate the percent gene coverage for all SC2 genes above the newly consolidated min_depth variable, and closes #113. 

This will require documentation changes because of the removal of task-level min_depth variables and creation of a single workflow-level min_depth variable.