### PR TITLE
pangolin v4 & updating nextclade defaults across 6 workflows

### DIFF
--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -260,7 +260,7 @@ task nextclade_one_sample {
       File? gene_annotations_json
       File? pcr_primers_csv
       File? virus_properties
-      String docker = "nextstrain/nextclade:1.10.3"
+      String docker = "nextstrain/nextclade:1.11.0"
       String dataset_name
       String dataset_reference
       String dataset_tag

--- a/workflows/wf_pangolin_update.wdl
+++ b/workflows/wf_pangolin_update.wdl
@@ -15,7 +15,7 @@ workflow pangolin_update {
     String? timezone
     File? lineage_log
   }
-  call taxon_ID.pangolin3 {
+  call taxon_ID.pangolin4 {
     input:
       samplename = samplename,
       fasta = assembly,
@@ -28,10 +28,10 @@ workflow pangolin_update {
       current_pangolin_docker = current_pangolin_docker,
       current_pangolin_assignment_version = current_pangolin_assignment_version,
       current_pangolin_versions = current_pangolin_versions,
-      updated_lineage = pangolin3.pangolin_lineage,
-      updated_pangolin_docker = pangolin3.pangolin_docker,
-      updated_pangolin_assignment_version = pangolin3.pangolin_assignment_version,
-      updated_pangolin_versions = pangolin3.pangolin_versions,
+      updated_lineage = pangolin4.pangolin_lineage,
+      updated_pangolin_docker = pangolin4.pangolin_docker,
+      updated_pangolin_assignment_version = pangolin4.pangolin_assignment_version,
+      updated_pangolin_versions = pangolin4.pangolin_versions,
       timezone = timezone,
       lineage_log = lineage_log
   }
@@ -44,13 +44,13 @@ workflow pangolin_update {
     String pangolin_update_version = version_capture.phvg_version
     String pangolin_update_analysis_date = version_capture.date
     # Pangolin Assignments
-    String pango_lineage = pangolin3.pangolin_lineage
-    String pangolin_conflicts = pangolin3.pangolin_conflicts
-    String pangolin_notes = pangolin3.pangolin_notes
-    String pangolin_assignment_version = pangolin3.pangolin_assignment_version
-    String pangolin_versions = pangolin3.pangolin_versions
-    File   pango_lineage_report = pangolin3.pango_lineage_report
-    String pangolin_docker = pangolin3.pangolin_docker
+    String pango_lineage = pangolin4.pangolin_lineage
+    String pangolin_conflicts = pangolin4.pangolin_conflicts
+    String pangolin_notes = pangolin4.pangolin_notes
+    String pangolin_assignment_version = pangolin4.pangolin_assignment_version
+    String pangolin_versions = pangolin4.pangolin_versions
+    File   pango_lineage_report = pangolin4.pango_lineage_report
+    String pangolin_docker = pangolin4.pangolin_docker
     # Update Log
     String pangolin_updates = pangolin_update_log.pangolin_updates
     File pango_lineage_log = pangolin_update_log.pango_lineage_log

--- a/workflows/wf_theiacov_clearlabs.wdl
+++ b/workflows/wf_theiacov_clearlabs.wdl
@@ -20,7 +20,7 @@ workflow theiacov_clearlabs {
     Int? normalise = 20000
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-02-07T12:00:00Z"
+    String nextclade_dataset_tag = "2022-03-31T12:00:00Z"
     String medaka_docker = "quay.io/staphb/artic-ncov2019:1.3.0-medaka-1.4.3"
   }
   call qc_utils.fastq_scan_se as fastq_scan_raw_reads {
@@ -63,7 +63,7 @@ workflow theiacov_clearlabs {
       samplename = samplename,
       bamfile = consensus.trim_sorted_bam
   }
-  call taxon_ID.pangolin3 {
+  call taxon_ID.pangolin4 {
     input:
       samplename = samplename,
       fasta = consensus.consensus_seq
@@ -127,13 +127,13 @@ workflow theiacov_clearlabs {
     Int number_Total = consensus_qc.number_Total
     Float percent_reference_coverage = consensus_qc.percent_reference_coverage
     # Lineage Assignment
-    String pango_lineage = pangolin3.pangolin_lineage
-    String pangolin_conflicts = pangolin3.pangolin_conflicts
-    String pangolin_notes = pangolin3.pangolin_notes
-    String pangolin_assignment_version = pangolin3.pangolin_assignment_version
-    File pango_lineage_report= pangolin3.pango_lineage_report
-    String pangolin_docker = pangolin3.pangolin_docker
-    String pangolin_versions = pangolin3.pangolin_versions
+    String pango_lineage = pangolin4.pangolin_lineage
+    String pangolin_conflicts = pangolin4.pangolin_conflicts
+    String pangolin_notes = pangolin4.pangolin_notes
+    String pangolin_assignment_version = pangolin4.pangolin_assignment_version
+    File pango_lineage_report= pangolin4.pango_lineage_report
+    String pangolin_docker = pangolin4.pangolin_docker
+    String pangolin_versions = pangolin4.pangolin_versions
     # Alignment QC
     File consensus_stats = stats_n_coverage.stats
     File consensus_flagstat = stats_n_coverage.flagstat

--- a/workflows/wf_theiacov_clearlabs.wdl
+++ b/workflows/wf_theiacov_clearlabs.wdl
@@ -141,6 +141,8 @@ workflow theiacov_clearlabs {
     Float meanmapq_trim = stats_n_coverage_primtrim.meanmapq
     Float assembly_mean_coverage = stats_n_coverage_primtrim.depth
     Float s_gene_mean_coverage = stats_n_coverage_primtrim.s_gene_depth
+    Float s_gene_percent_coverage = stats_n_coverage_primtrim.s_gene_percent_coverage
+    File percent_gene_coverage = stats_n_coverage_primtrim.percent_gene_coverage
     String samtools_version = stats_n_coverage.samtools_version
     # Clade Assigment
     File nextclade_json = nextclade_one_sample.nextclade_json

--- a/workflows/wf_theiacov_fasta.wdl
+++ b/workflows/wf_theiacov_fasta.wdl
@@ -19,13 +19,13 @@ workflow theiacov_fasta {
     String input_assembly_method
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-02-07T12:00:00Z"
+    String nextclade_dataset_tag = "2022-03-31T12:00:00Z"
   }
   call qc_utils.consensus_qc {
     input:
       assembly_fasta = assembly_fasta
   }
-  call taxon_ID.pangolin3 {
+  call taxon_ID.pangolin4 {
     input:
       samplename = samplename,
       fasta = assembly_fasta
@@ -63,13 +63,13 @@ workflow theiacov_fasta {
     Int number_Total = consensus_qc.number_Total
     Float percent_reference_coverage = consensus_qc.percent_reference_coverage
     # Lineage Assignment
-    String pango_lineage = pangolin3.pangolin_lineage
-    String pangolin_conflicts = pangolin3.pangolin_conflicts
-    String pangolin_notes = pangolin3.pangolin_notes
-    String pangolin_assignment_version = pangolin3.pangolin_assignment_version
-    File pango_lineage_report = pangolin3.pango_lineage_report
-    String pangolin_docker = pangolin3.pangolin_docker
-    String pangolin_versions = pangolin3.pangolin_versions
+    String pango_lineage = pangolin4.pangolin_lineage
+    String pangolin_conflicts = pangolin4.pangolin_conflicts
+    String pangolin_notes = pangolin4.pangolin_notes
+    String pangolin_assignment_version = pangolin4.pangolin_assignment_version
+    File pango_lineage_report = pangolin4.pango_lineage_report
+    String pangolin_docker = pangolin4.pangolin_docker
+    String pangolin_versions = pangolin4.pangolin_versions
     # Clade Assigment
     File nextclade_json = nextclade_one_sample.nextclade_json
     File auspice_json = nextclade_one_sample.auspice_json

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -21,7 +21,7 @@ workflow theiacov_illumina_pe {
     File primer_bed
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-02-07T12:00:00Z"
+    String nextclade_dataset_tag = "2022-03-31T12:00:00Z"
     File? reference_genome
     Int min_depth = 100
   }
@@ -74,7 +74,7 @@ workflow theiacov_illumina_pe {
       bamfile = primer_trim.trim_sorted_bam,
       min_depth = min_depth
   }
-  call taxon_ID.pangolin3 {
+  call taxon_ID.pangolin4 {
     input:
       samplename = samplename,
       fasta = consensus.consensus_seq
@@ -159,13 +159,13 @@ workflow theiacov_illumina_pe {
     File percent_gene_coverage = stats_n_coverage_primtrim.percent_gene_coverage
     String samtools_version_stats = stats_n_coverage.samtools_version
     # Lineage Assignment
-    String pango_lineage = pangolin3.pangolin_lineage
-    String pangolin_conflicts = pangolin3.pangolin_conflicts
-    String pangolin_notes = pangolin3.pangolin_notes
-    String pangolin_assignment_version = pangolin3.pangolin_assignment_version
-    File pango_lineage_report = pangolin3.pango_lineage_report
-    String pangolin_docker = pangolin3.pangolin_docker
-    String pangolin_versions = pangolin3.pangolin_versions
+    String pango_lineage = pangolin4.pangolin_lineage
+    String pangolin_conflicts = pangolin4.pangolin_conflicts
+    String pangolin_notes = pangolin4.pangolin_notes
+    String pangolin_assignment_version = pangolin4.pangolin_assignment_version
+    File pango_lineage_report = pangolin4.pango_lineage_report
+    String pangolin_docker = pangolin4.pangolin_docker
+    String pangolin_versions = pangolin4.pangolin_versions
     # Clade Assigment
     File nextclade_json = nextclade_one_sample.nextclade_json
     File auspice_json = nextclade_one_sample.auspice_json

--- a/workflows/wf_theiacov_illumina_se.wdl
+++ b/workflows/wf_theiacov_illumina_se.wdl
@@ -20,7 +20,7 @@ workflow theiacov_illumina_se {
     File primer_bed
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-02-07T12:00:00Z"
+    String nextclade_dataset_tag = "2022-03-31T12:00:00Z"
     File? reference_genome
     Int min_depth = 100
   }
@@ -71,7 +71,7 @@ workflow theiacov_illumina_se {
       bamfile = primer_trim.trim_sorted_bam,
       min_depth = min_depth
   }
-  call taxon_ID.pangolin3 {
+  call taxon_ID.pangolin4 {
     input:
       samplename = samplename,
       fasta = consensus.consensus_seq
@@ -149,13 +149,13 @@ workflow theiacov_illumina_se {
     File percent_gene_coverage = stats_n_coverage_primtrim.percent_gene_coverage
     String samtools_version_stats = stats_n_coverage.samtools_version
     # Lineage Assignment
-    String pango_lineage = pangolin3.pangolin_lineage
-    String pangolin_conflicts = pangolin3.pangolin_conflicts
-    String pangolin_notes = pangolin3.pangolin_notes
-    String pangolin_assignment_version = pangolin3.pangolin_assignment_version
-    File pango_lineage_report = pangolin3.pango_lineage_report
-    String pangolin_docker = pangolin3.pangolin_docker
-    String pangolin_versions = pangolin3.pangolin_versions
+    String pango_lineage = pangolin4.pangolin_lineage
+    String pangolin_conflicts = pangolin4.pangolin_conflicts
+    String pangolin_notes = pangolin4.pangolin_notes
+    String pangolin_assignment_version = pangolin4.pangolin_assignment_version
+    File pango_lineage_report = pangolin4.pango_lineage_report
+    String pangolin_docker = pangolin4.pangolin_docker
+    String pangolin_versions = pangolin4.pangolin_versions
     # Clade Assigment
     File nextclade_json = nextclade_one_sample.nextclade_json
     File auspice_json = nextclade_one_sample.auspice_json

--- a/workflows/wf_theiacov_ont.wdl
+++ b/workflows/wf_theiacov_ont.wdl
@@ -20,7 +20,7 @@ workflow theiacov_ont {
     Int? normalise = 200
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-02-07T12:00:00Z"
+    String nextclade_dataset_tag = "2022-03-31T12:00:00Z"
     Int? max_length = 700
     Int? min_length = 400
   }
@@ -70,7 +70,7 @@ workflow theiacov_ont {
       samplename = samplename,
       bamfile = consensus.trim_sorted_bam
   }
-  call taxon_ID.pangolin3 {
+  call taxon_ID.pangolin4 {
     input:
       samplename = samplename,
       fasta = consensus.consensus_seq
@@ -142,13 +142,13 @@ workflow theiacov_ont {
     Float s_gene_mean_coverage = stats_n_coverage_primtrim.s_gene_depth
     String samtools_version = stats_n_coverage.samtools_version
     # Lineage Assignment
-    String pango_lineage = pangolin3.pangolin_lineage
-    String pangolin_conflicts = pangolin3.pangolin_conflicts
-    String pangolin_notes = pangolin3.pangolin_notes
-    String pangolin_assignment_version = pangolin3.pangolin_assignment_version
-    File pango_lineage_report = pangolin3.pango_lineage_report
-    String pangolin_docker = pangolin3.pangolin_docker
-    String pangolin_versions = pangolin3.pangolin_versions
+    String pango_lineage = pangolin4.pangolin_lineage
+    String pangolin_conflicts = pangolin4.pangolin_conflicts
+    String pangolin_notes = pangolin4.pangolin_notes
+    String pangolin_assignment_version = pangolin4.pangolin_assignment_version
+    File pango_lineage_report = pangolin4.pango_lineage_report
+    String pangolin_docker = pangolin4.pangolin_docker
+    String pangolin_versions = pangolin4.pangolin_versions
     # Clade Assigment
     File nextclade_json = nextclade_one_sample.nextclade_json
     File auspice_json = nextclade_one_sample.auspice_json

--- a/workflows/wf_theiacov_ont.wdl
+++ b/workflows/wf_theiacov_ont.wdl
@@ -140,6 +140,8 @@ workflow theiacov_ont {
     Float meanmapq_trim = stats_n_coverage_primtrim.meanmapq
     Float assembly_mean_coverage = stats_n_coverage_primtrim.depth
     Float s_gene_mean_coverage = stats_n_coverage_primtrim.s_gene_depth
+    Float s_gene_percent_coverage = stats_n_coverage_primtrim.s_gene_percent_coverage
+    File percent_gene_coverage = stats_n_coverage_primtrim.percent_gene_coverage    
     String samtools_version = stats_n_coverage.samtools_version
     # Lineage Assignment
     String pango_lineage = pangolin4.pangolin_lineage


### PR DESCRIPTION
Starting as a draft PR until all workflows are tested in Terra.

This PR includes:
* Added pangolin4 task:
  * Copied pangolin3 task, updated pangolin flags
  * updated python code to parse output CSV
  * `inference_engine` input param is now called `analysis_mode`.
    * For UShER mode, users need to either leave this input param blank, or enter `usher` or `accurate`
    * For pangolearn mode, users need to enter either `pangolearn` or `fast`
    *  🔼 Need to communicate this to users
  * Docker image: `quay.io/staphb/pangolin:4.0.2-pdata-1.2.133`
  * Workflows updated to use pangolin4 task instead of pangolin3:
    * workflows/wf_pangolin_update.wdl
    * workflows/wf_theiacov_clearlabs.wdl
    * workflows/wf_theiacov_fasta.wdl
    * workflows/wf_theiacov_illumina_se.wdl
    * workflows/wf_theiacov_illumina_pe.wdl
    * workflows/wf_theiacov_ont.wdl
* Updates the same 6 workflows with the latest nextclade_dataset_tag `2022-03-31T12:00:00Z` and docker image `nextstrain/nextclade:1.11.0`


I have tested theiacov_fasta in this workspace in `omicron_pango_validation` table: https://app.terra.bio/#workspaces/theiagen-validations/workflow_validations/data

planning to test other data types next illumina PE and SE, ClearLabs, and ONT

