### PR TITLE
Update to Freyja v1.3.4

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -95,8 +95,3 @@ workflows:
    primaryDescriptorPath: /workflows/wf_theiacov_augur_distance_tree.wdl
    testParameterFiles:
     - empty.json
- - name: Freyja_Update
-   subclass: WDL
-   primaryDescriptorPath: /workflows/wf_freyja_update.wdl
-   testParameterFiles:
-    - empty.json

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -95,3 +95,8 @@ workflows:
    primaryDescriptorPath: /workflows/wf_theiacov_augur_distance_tree.wdl
    testParameterFiles:
     - empty.json
+ - name: Freyja_Update
+   subclass: WDL
+   primaryDescriptorPath: /workflows/wf_freyja_update.wdl
+   testParameterFiles:
+    - empty.json

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -307,49 +307,52 @@ task freyja_one_sample {
     File reference_genome
     File? freyja_usher_barcodes
     File? freyja_lineage_metadata
-    Float? eps=0.001
+    Float? eps
     Boolean update_db = false
-    String docker = "quay.io/staphb/freyja:1.3.2"
+    String docker = "quay.io/staphb/freyja:1.3.4"
   }
   command <<<
   # update freyja reference files if specified
   if ~{update_db}; then 
       freyja update
       # can't update barcodes in freyja 1.3.2; will update known issue is closed (https://github.com/andersen-lab/Freyja/issues/33)
-      freyja_usher_barcode_version="unmodified from freyja container: ~{docker}"
-      freyja_barcode=""
+      freyja_usher_barcode_version="freyja update: $(date +"%Y-%m-%d")"
       freyja_metadata_version="freyja update: $(date +"%Y-%m-%d")"
-      freyja_metadata=""  
   else
   # configure barcode    
     if [[ ! -z "~{freyja_usher_barcodes}" ]]; then
       echo "User freyja usher barcodes identified; ~{freyja_usher_barcodes} will be utilized fre freyja demixing"
-      freyja_barcode="--barcodes ~{freyja_usher_barcodes}"
       freyja_usher_barcode_version=$(basename -- "~{freyja_usher_barcodes}")
     else
-      freyja_barcode=""
       freyja_usher_barcode_version="unmodified from freyja container: ~{docker}"  
     fi
     # configure lineage metadata
     if [[ ! -z "~{freyja_lineage_metadata}" ]]; then
       echo "User lineage metadata; ~{freyja_lineage_metadata} will be utilized fre freyja demixing"
-      freyja_metadata="--meta ~{freyja_lineage_metadata}"
       freyja_metadata_version=$(basename -- "~{freyja_lineage_metadata}")
     else
-      freyja_metadata=""  
       freyja_metadata_version="unmodified from freyja container: ~{docker}"
     fi
   fi
   # Capture reference file versions
   echo ${freyja_usher_barcode_version} | tee FREYJA_BARCODES
   echo ${freyja_metadata_version} | tee FREYJA_METADATA
-  echo $PWD
   # Call variants and capture sequencing depth information
   echo "Running: freyja variants ~{primer_trimmed_bam} --variants ~{samplename}_freyja_variants.tsv --depths ~{samplename}_freyja_depths.tsv --ref ~{reference_genome}"
-  freyja variants ~{primer_trimmed_bam} --variants ~{samplename}_freyja_variants.tsv --depths ~{samplename}_freyja_depths.tsv --ref ~{reference_genome}
+  freyja variants \
+    ~{primer_trimmed_bam} \
+    --variants ~{samplename}_freyja_variants.tsv \
+    --depths ~{samplename}_freyja_depths.tsv \
+    --ref ~{reference_genome}
   # Demix variants 
   echo "Running: freyja demix --eps ~{eps} ${freyja_barcode} ${freyja_metadata} ~{samplename}_freyja_variants.tsv ~{samplename}_freyja_depths.tsv --output ~{samplename}_freyja_demixed.tmp"
-  freyja demix --eps ~{eps} ${freyja_barcode} ${freyja_metadata} ~{samplename}_freyja_variants.tsv ~{samplename}_freyja_depths.tsv --output ~{samplename}_freyja_demixed.tmp
+  freyja demix \
+    ~{'--eps ' + eps} \
+    ~{'--meta ' + freyja_lineage_metadata} \
+    ~{'--barcodes ' + freyja_usher_barcodes} \
+    ~{samplename}_freyja_variants.tsv \
+    ~{samplename}_freyja_depths.tsv \
+    --output ~{samplename}_freyja_demixed.tmp
   # Adjust output header
   echo -e "\t/~{samplename}" > ~{samplename}_freyja_demixed.tsv
   tail -n+2 ~{samplename}_freyja_demixed.tmp >> ~{samplename}_freyja_demixed.tsv

--- a/workflows/wf_freyja_update.wdl
+++ b/workflows/wf_freyja_update.wdl
@@ -25,10 +25,10 @@ task freyja_update_refs {
   }
   command <<<
   # Create updated refrence files
-  mkdir freyja_ref_files
-  freyja update --outdir freyja_ref_files 
+  freyja update --outdir $PWD 
   
-  echo "Freyja reference files created using the freyja update command; Freyja Docker Image utilized: ~{docker}. More information can be found at https://github.com/andersen-lab/Freyja" > freyja_ref_files/update_log.txt
+  find / -name "lineagePaths.txt"
+  echo "Freyja reference files created using the freyja update command; Freyja Docker Image utilized: ~{docker}. More information can be found at https://github.com/andersen-lab/Freyja" > $PWD/update_log.txt
   >>>
   runtime {
     memory: "4 GB"
@@ -37,9 +37,9 @@ task freyja_update_refs {
     disks: "local-disk 100 HDD"
   }
   output {
-    File updated_barcodes = "freyja_ref_files/usher_barcodes.csv"
-    File updated_lineages = "freyja_ref_files/curated_lineages.json"
-    File update_log = "freyja_ref_files/update_log.txt"
+    File updated_barcodes = "usher_barcodes.csv"
+    File updated_lineages = "curated_lineages.json"
+    File update_log = "update_log.txt"
   }
 }
 task transfer_files {

--- a/workflows/wf_freyja_update.wdl
+++ b/workflows/wf_freyja_update.wdl
@@ -24,9 +24,7 @@ task freyja_update_refs {
     String docker = "staphb/freyja:1.3.4"
   }
   command <<<
-  # Create date tag 
-  date_tag=$(date +"%Y-%m-%d")
-  
+  # Create updated refrence files
   freyja update --outdir .
   
   echo "Freyja reference files created using the freyja update command; Freyja Docker Image utilized: ~{docker}. More information can be found at https://github.com/andersen-lab/Freyja" > update_log.txt

--- a/workflows/wf_freyja_update.wdl
+++ b/workflows/wf_freyja_update.wdl
@@ -29,7 +29,6 @@ task freyja_update_refs {
   echo "PWD: $PWD"
   freyja update --outdir $PWD
   
-  find / -name "lineagePaths.txt"
   echo "Freyja reference files created using the freyja update command; Freyja Docker Image utilized: ~{docker}. More information can be found at https://github.com/andersen-lab/Freyja" > $PWD/update_log.txt
   >>>
   runtime {

--- a/workflows/wf_freyja_update.wdl
+++ b/workflows/wf_freyja_update.wdl
@@ -25,7 +25,9 @@ task freyja_update_refs {
   }
   command <<<
   # Create updated refrence files
-  freyja update --outdir $PWD 
+  mkdir freyja_update_refs && cd freyja_update_refs
+  echo "PWD: $PWD"
+  freyja update --outdir $PWD
   
   find / -name "lineagePaths.txt"
   echo "Freyja reference files created using the freyja update command; Freyja Docker Image utilized: ~{docker}. More information can be found at https://github.com/andersen-lab/Freyja" > $PWD/update_log.txt
@@ -37,9 +39,9 @@ task freyja_update_refs {
     disks: "local-disk 100 HDD"
   }
   output {
-    File updated_barcodes = "usher_barcodes.csv"
-    File updated_lineages = "curated_lineages.json"
-    File update_log = "update_log.txt"
+    File updated_barcodes = "freyja_update_refs/usher_barcodes.csv"
+    File updated_lineages = "freyja_update_refs/curated_lineages.json"
+    File update_log = "freyja_update_refs/update_log.txt"
   }
 }
 task transfer_files {

--- a/workflows/wf_freyja_update.wdl
+++ b/workflows/wf_freyja_update.wdl
@@ -21,13 +21,12 @@ workflow freyja_update {
 task freyja_update_refs {
   input {
     String gcp_uri
-    String docker = "quay.io/staphb/freyja:1.3.4"
+    String docker = "staphb/freyja:1.3.4"
   }
   command <<<
   # Create date tag 
   date_tag=$(date +"%Y-%m-%d")
   
-  mkdir freyja_reference_files
   freyja update --outdir .
   
   echo "Freyja reference files created using the freyja update command; Freyja Docker Image utilized: ~{docker}. More information can be found at https://github.com/andersen-lab/Freyja" > update_log.txt

--- a/workflows/wf_freyja_update.wdl
+++ b/workflows/wf_freyja_update.wdl
@@ -1,0 +1,69 @@
+version 1.0
+
+workflow freyja_update {
+  input {
+    String gcp_uri
+  }
+  call freyja_update_refs {
+    input:
+      gcp_uri = gcp_uri
+  }
+  call transfer_files {
+    input:
+      updated_barcodes = freyja_update_refs.updated_barcodes,
+      updated_lineages = freyja_update_refs.updated_lineages,
+      update_log = freyja_update_refs.update_log,
+      gcp_uri = gcp_uri
+  }
+  output {
+  }
+}
+task freyja_update_refs {
+  input {
+    String gcp_uri
+    String docker = "quay.io/staphb/freyja:1.3.4"
+  }
+  command <<<
+  # Create date tag 
+  date_tag=$(date +"%Y-%m-%d")
+  
+  mkdir freyja_reference_files
+  freyja update --outdir .
+  
+  echo "Freyja reference files created using the freyja update command; Freyja Docker Image utilized: ~{docker}. More information can be found at https://github.com/andersen-lab/Freyja" > update_log.txt
+  >>>
+  runtime {
+    memory: "4 GB"
+    cpu: 2
+    docker: "~{docker}"
+    disks: "local-disk 100 HDD"
+  }
+  output {
+    File updated_barcodes = "usher_barcodes.csv"
+    File updated_lineages = "curated_lineages.json"
+    File update_log = "update_log.txt"
+  }
+}
+task transfer_files {
+  input {
+    String gcp_uri
+    File updated_barcodes
+    File updated_lineages
+    File update_log
+  }
+  command <<<
+  # transfer_files to specified gcp_uri
+  date_tag=$(date +"%Y-%m-%d")
+  
+  gsutil -m cp ~{updated_barcodes} ~{updated_lineages} ~{update_log} ~{gcp_uri}/${date_tag}
+  
+  >>>
+  runtime {
+    memory: "4 GB"
+    cpu: 2
+    docker: "theiagen/utility:1.1"
+    disks: "local-disk 100 HDD"
+  }
+  output {    
+  }
+}

--- a/workflows/wf_freyja_update.wdl
+++ b/workflows/wf_freyja_update.wdl
@@ -25,9 +25,10 @@ task freyja_update_refs {
   }
   command <<<
   # Create updated refrence files
-  freyja update --outdir .
+  mkdir freyja_ref_files
+  freyja update --outdir freyja_ref_files 
   
-  echo "Freyja reference files created using the freyja update command; Freyja Docker Image utilized: ~{docker}. More information can be found at https://github.com/andersen-lab/Freyja" > update_log.txt
+  echo "Freyja reference files created using the freyja update command; Freyja Docker Image utilized: ~{docker}. More information can be found at https://github.com/andersen-lab/Freyja" > freyja_ref_files/update_log.txt
   >>>
   runtime {
     memory: "4 GB"
@@ -36,9 +37,9 @@ task freyja_update_refs {
     disks: "local-disk 100 HDD"
   }
   output {
-    File updated_barcodes = "usher_barcodes.csv"
-    File updated_lineages = "curated_lineages.json"
-    File update_log = "update_log.txt"
+    File updated_barcodes = "freyja_ref_files/usher_barcodes.csv"
+    File updated_lineages = "freyja_ref_files/curated_lineages.json"
+    File update_log = "freyja_ref_files/update_log.txt"
   }
 }
 task transfer_files {


### PR DESCRIPTION
This PR adjusts the Freyja workflow and tasks to utilize Freyja v1.3.4. A functional `freyja_update.wdl` task has also been created, though not included in the .dockstore.yml as issues persist when utilizing the workflow on the Terra.Bio platform; seemingly due to [permission/access issues discussed here](https://github.com/StaPH-B/docker-builds/issues/335). 

Will include this in .dockstore.yml in a future PR once these issues can be resolved