### PR TITLE
Enables --skip-scorpio functionality

### DIFF
--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -129,6 +129,7 @@ task pangolin4 {
     Float max_ambig = 0.5
     String docker = "quay.io/staphb/pangolin:4.0.4-pdata-1.2.133"
     String? analysis_mode
+    String? pangolin_arguments
   }
   command <<<
     set -e
@@ -143,7 +144,8 @@ task pangolin4 {
        ~{'--min-length ' + min_length} \
        ~{'--max-ambig ' + max_ambig} \
        --outfile "~{samplename}.pangolin_report.csv" \
-       --verbose
+       --verbose \
+       ~{pangolin_arguments}
 
     python3 <<CODE
     import csv


### PR DESCRIPTION
This PR adds a new variable `pangolin_arguments` which is a free text input variable where a user can type in various additional arguments they want applied to their pangolin tasks. The current intended use-case is to enable the `--skip-scorpio` option. Although there is the high potential that this option will be prone to user typos, this option is the most future-proof for any additional optional flags that the pangolin team may want to implement.