### PR TITLE
Fix PHVG v2.1.1 bug and update default images and tags

### DIFF
--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -127,7 +127,7 @@ task pangolin4 {
     String samplename
     Int min_length = 10000
     Float max_ambig = 0.5
-    String docker = "quay.io/staphb/pangolin:4.0.4-pdata-1.2.133"
+    String docker = "staphb/pangolin:4.0.6-pdata-1.8"
     String? analysis_mode
     String? pangolin_arguments
   }

--- a/tasks/task_versioning.wdl
+++ b/tasks/task_versioning.wdl
@@ -8,7 +8,7 @@ task version_capture {
     volatile: true
   }
   command <<<
-    PHVG_Version="PHVG v2.1.1"
+    PHVG_Version="PHVG v2.1.2"
     ~{default='' 'export TZ=' + timezone}
     date +"%Y-%m-%d" > TODAY
     echo $PHVG_Version > PHVG_VERSION

--- a/tasks/tasks_nextstrain.wdl
+++ b/tasks/tasks_nextstrain.wdl
@@ -1770,16 +1770,15 @@ task prep_augur_metadata {
   }
   command <<<
     # de-identified consensus/assembly sequence
-    year=$(echo ${collection_date} | cut -f 1 -d '-')
+    year=$(echo ~{collection_date} | cut -f 1 -d '-')
 
     echo -e "strain\tvirus\tdate\tregion\tcountry\tdivision\tlocation\tpango_lineage" > augur_metadata.tsv
 
     # Set strain name by assembly header
     assembly_header=$(grep -e ">" ~{assembly} | sed 's/\s.*$//' |  sed 's/>//g' )
 
-    echo -e "\"$assembly_header\"\t\"ncov\"\t\"${collection_date}\"\t\"${iso_continent}\" \t\"${iso_country}\"\t\"${iso_state}\"\t\"${iso_county}\"\t"${pango_lineage}"" >> augur_metadata.tsv
+    echo -e "\"$assembly_header\"\t\"ncov\"\t\"~{collection_date}\"\t\"~{iso_continent}\" \t\"~{iso_country}\"\t\"~{iso_state}\"\t\"~{iso_county}\"\t\"~{pango_lineage}\"" >> augur_metadata.tsv
 
-    echo $(ls )
   >>>
   output {
     File     augur_metadata = "augur_metadata.tsv"

--- a/workflows/wf_theiacov_clearlabs.wdl
+++ b/workflows/wf_theiacov_clearlabs.wdl
@@ -20,7 +20,7 @@ workflow theiacov_clearlabs {
     Int? normalise = 20000
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-03-31T12:00:00Z"
+    String nextclade_dataset_tag = "2022-04-28T12:00:00Z"
     String medaka_docker = "quay.io/staphb/artic-ncov2019:1.3.0-medaka-1.4.3"
   }
   call qc_utils.fastq_scan_se as fastq_scan_raw_reads {

--- a/workflows/wf_theiacov_fasta.wdl
+++ b/workflows/wf_theiacov_fasta.wdl
@@ -19,7 +19,7 @@ workflow theiacov_fasta {
     String input_assembly_method
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-03-31T12:00:00Z"
+    String nextclade_dataset_tag = "2022-04-28T12:00:00Z"
   }
   call qc_utils.consensus_qc {
     input:

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -21,7 +21,7 @@ workflow theiacov_illumina_pe {
     File primer_bed
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-03-31T12:00:00Z"
+    String nextclade_dataset_tag = "2022-04-28T12:00:00Z"
     File? reference_genome
     Int min_depth = 100
   }

--- a/workflows/wf_theiacov_illumina_se.wdl
+++ b/workflows/wf_theiacov_illumina_se.wdl
@@ -20,7 +20,7 @@ workflow theiacov_illumina_se {
     File primer_bed
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-03-31T12:00:00Z"
+    String nextclade_dataset_tag = "2022-04-28T12:00:00Z"
     File? reference_genome
     Int min_depth = 100
   }

--- a/workflows/wf_theiacov_ont.wdl
+++ b/workflows/wf_theiacov_ont.wdl
@@ -20,7 +20,7 @@ workflow theiacov_ont {
     Int? normalise = 200
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-03-31T12:00:00Z"
+    String nextclade_dataset_tag = "2022-04-28T12:00:00Z"
     Int? max_length = 700
     Int? min_length = 400
   }


### PR DESCRIPTION
This PR fixes the bug that occured when changes to the wdl command block syntax required different variable indicators. This PR also updates the default `pangolin_docker_image`  to be `staphb/pangolin:4.0.6-pdata-1.8` and the `nextclade_dataset_tag` to be `2022-04-28T12:00:00Z`.