### PR TITLE
Update TheiaCoV workflows to utilize nextclade v2

### DIFF
--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -262,7 +262,7 @@ task nextclade_one_sample {
       File? gene_annotations_json
       File? pcr_primers_csv
       File? virus_properties
-      String docker = "nextstrain/nextclade:2.0.0"
+      String docker = "nextstrain/nextclade:2.3.0"
       String dataset_name
       String dataset_reference
       String dataset_tag

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -294,7 +294,7 @@ task nextclade_one_sample {
       cpu: 2
       disks: "local-disk 50 HDD"
       dx_instance_type: "mem1_ssd1_v2_x2"
-   #   maxRetries: 3 
+      maxRetries: 3 
     }
     output {
       String nextclade_version = read_string("NEXTCLADE_VERSION")

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -262,7 +262,7 @@ task nextclade_one_sample {
       File? gene_annotations_json
       File? pcr_primers_csv
       File? virus_properties
-      String docker = "nextstrain/nextclade:1.11.0"
+      String docker = "nextstrain/nextclade:2.0.0"
       String dataset_name
       String dataset_reference
       String dataset_tag
@@ -274,18 +274,20 @@ task nextclade_one_sample {
 
         nextclade dataset get --name="~{dataset_name}" --reference="~{dataset_reference}" --tag="~{dataset_tag}" -o nextclade_dataset_dir --verbose
         set -e
-        nextclade run --input-fasta "~{genome_fasta}" \
-            --input-dataset "nextclade_dataset_dir" \
-            --input-root-seq ~{default="nextclade_dataset_dir/reference.fasta" root_sequence} \
-            --input-tree ~{default="nextclade_dataset_dir/tree.json" auspice_reference_tree_json} \
-            --input-qc-config ~{default="nextclade_dataset_dir/qc.json" qc_config_json} \
-            --input-gene-map ~{default="nextclade_dataset_dir/genemap.gff" gene_annotations_json} \
-            --input-pcr-primers ~{default="nextclade_dataset_dir/primers.csv" pcr_primers_csv} \
-            --input-virus-properties ~{default="nextclade_dataset_dir/virus_properties.json" virus_properties} \
+        nextclade run \
+            --input-dataset=nextclade_dataset_dir/ \
+            ~{"--input-root-seq " + root_sequence} \
+            ~{"--input-tree " + auspice_reference_tree_json} \
+            ~{"--input-qc-config " + qc_config_json} \
+            ~{"--input-gene-map " + gene_annotations_json} \
+            ~{"--input-pcr-primers " + pcr_primers_csv} \
+            ~{"--input-virus-properties " + virus_properties}  \
+            --output-basename "~{basename}" \
             --output-json "~{basename}".nextclade.json \
             --output-tsv  "~{basename}".nextclade.tsv \
             --output-tree "~{basename}".nextclade.auspice.json \
-            --verbose
+            --output-all=. \
+            "~{genome_fasta}"
     >>>
     runtime {
       docker: "~{docker}"
@@ -293,7 +295,7 @@ task nextclade_one_sample {
       cpu: 2
       disks: "local-disk 50 HDD"
       dx_instance_type: "mem1_ssd1_v2_x2"
-      maxRetries: 3 
+   #   maxRetries: 3 
     }
     output {
       String nextclade_version = read_string("NEXTCLADE_VERSION")

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -282,7 +282,6 @@ task nextclade_one_sample {
             ~{"--input-gene-map " + gene_annotations_json} \
             ~{"--input-pcr-primers " + pcr_primers_csv} \
             ~{"--input-virus-properties " + virus_properties}  \
-            --output-basename "~{basename}" \
             --output-json "~{basename}".nextclade.json \
             --output-tsv  "~{basename}".nextclade.tsv \
             --output-tree "~{basename}".nextclade.auspice.json \

--- a/workflows/wf_theiacov_clearlabs.wdl
+++ b/workflows/wf_theiacov_clearlabs.wdl
@@ -20,7 +20,7 @@ workflow theiacov_clearlabs {
     Int? normalise = 20000
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-06-14T12:00:00Z"
+    String nextclade_dataset_tag = "2022-07-11T12:00:00Z"
     String medaka_docker = "quay.io/staphb/artic-ncov2019:1.3.0-medaka-1.4.3"
   }
   call qc_utils.fastq_scan_se as fastq_scan_raw_reads {

--- a/workflows/wf_theiacov_clearlabs.wdl
+++ b/workflows/wf_theiacov_clearlabs.wdl
@@ -20,7 +20,7 @@ workflow theiacov_clearlabs {
     Int? normalise = 20000
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-04-28T12:00:00Z"
+    String nextclade_dataset_tag = "2022-06-14T12:00:00Z"
     String medaka_docker = "quay.io/staphb/artic-ncov2019:1.3.0-medaka-1.4.3"
   }
   call qc_utils.fastq_scan_se as fastq_scan_raw_reads {

--- a/workflows/wf_theiacov_fasta.wdl
+++ b/workflows/wf_theiacov_fasta.wdl
@@ -19,7 +19,7 @@ workflow theiacov_fasta {
     String input_assembly_method
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-06-14T12:00:00Z"
+    String nextclade_dataset_tag = "2022-07-11T12:00:00Z"
   }
   call qc_utils.consensus_qc {
     input:

--- a/workflows/wf_theiacov_fasta.wdl
+++ b/workflows/wf_theiacov_fasta.wdl
@@ -19,7 +19,7 @@ workflow theiacov_fasta {
     String input_assembly_method
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-04-28T12:00:00Z"
+    String nextclade_dataset_tag = "2022-06-14T12:00:00Z"
   }
   call qc_utils.consensus_qc {
     input:

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -21,7 +21,7 @@ workflow theiacov_illumina_pe {
     File primer_bed
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-04-28T12:00:00Z"
+    String nextclade_dataset_tag = "2022-06-14T12:00:00Z"
     File? reference_genome
     Int min_depth = 100
   }

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -21,7 +21,7 @@ workflow theiacov_illumina_pe {
     File primer_bed
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-06-14T12:00:00Z"
+    String nextclade_dataset_tag = "2022-07-11T12:00:00Z"
     File? reference_genome
     Int min_depth = 100
   }

--- a/workflows/wf_theiacov_illumina_se.wdl
+++ b/workflows/wf_theiacov_illumina_se.wdl
@@ -20,7 +20,7 @@ workflow theiacov_illumina_se {
     File primer_bed
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-06-14T12:00:00Z"
+    String nextclade_dataset_tag = "2022-07-11T12:00:00Z"
     File? reference_genome
     Int min_depth = 100
   }

--- a/workflows/wf_theiacov_illumina_se.wdl
+++ b/workflows/wf_theiacov_illumina_se.wdl
@@ -20,7 +20,7 @@ workflow theiacov_illumina_se {
     File primer_bed
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-04-28T12:00:00Z"
+    String nextclade_dataset_tag = "2022-06-14T12:00:00Z"
     File? reference_genome
     Int min_depth = 100
   }

--- a/workflows/wf_theiacov_ont.wdl
+++ b/workflows/wf_theiacov_ont.wdl
@@ -20,7 +20,7 @@ workflow theiacov_ont {
     Int? normalise = 200
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-04-28T12:00:00Z"
+    String nextclade_dataset_tag = "2022-06-14T12:00:00Z"
     Int? max_length = 700
     Int? min_length = 400
   }

--- a/workflows/wf_theiacov_ont.wdl
+++ b/workflows/wf_theiacov_ont.wdl
@@ -20,7 +20,7 @@ workflow theiacov_ont {
     Int? normalise = 200
     String nextclade_dataset_name = "sars-cov-2"
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2022-06-14T12:00:00Z"
+    String nextclade_dataset_tag = "2022-07-11T12:00:00Z"
     Int? max_length = 700
     Int? min_length = 400
   }


### PR DESCRIPTION
This PR updates the `nextclade_one_sample` to utilize nextclade v2 as per the [developer guidance](https://github.com/nextstrain/nextclade/blob/master/CHANGELOG.md#nextclade-cli).

Mimicking a [updates detailed in viral-pipes](https://github.com/broadinstitute/viral-pipelines/pull/430)