### PR TITLE
New VADR output: `.zip` of output fasta files

### DIFF
--- a/tests/workflows/test_clearlabs.yml
+++ b/tests/workflows/test_clearlabs.yml
@@ -18,7 +18,7 @@
     - wf_theiacov_clearlabs_miniwdl
   files:
     - path: miniwdl_run/call-consensus/command
-      md5sum: 61afafe09299996ae4bec73d4606305b
+      md5sum: 8766aa99bf4cb3e4a1d7bb7a06439213
     - path: miniwdl_run/call-consensus/inputs.json
       contains: ["filtered_reads", "samplename", "fastq"]
     - path: miniwdl_run/call-consensus/outputs.json
@@ -474,7 +474,7 @@
     - path: miniwdl_run//wdl/tasks/quality_control/task_assembly_metrics.wdl
       md5sum: a5bd00f53895afd62bf216b314c488eb
     - path: miniwdl_run//wdl/tasks/quality_control/task_consensus_qc.wdl
-      md5sum: b250698371ecadca92d37233723837d0
+      md5sum: 9885debe1ad812ca22094c462e229281
     - path: miniwdl_run//wdl/tasks/quality_control/task_fastq_scan.wdl
       md5sum: 7584c321243c18b70b7f18e91fa019df
     - path: miniwdl_run/wdl/tasks/task_ncbi.wdl

--- a/tests/workflows/test_clearlabs.yml
+++ b/tests/workflows/test_clearlabs.yml
@@ -18,7 +18,7 @@
     - wf_theiacov_clearlabs_miniwdl
   files:
     - path: miniwdl_run/call-consensus/command
-      md5sum: 8766aa99bf4cb3e4a1d7bb7a06439213
+      md5sum: 61afafe09299996ae4bec73d4606305b
     - path: miniwdl_run/call-consensus/inputs.json
       contains: ["filtered_reads", "samplename", "fastq"]
     - path: miniwdl_run/call-consensus/outputs.json
@@ -88,7 +88,7 @@
     - path: miniwdl_run/call-consensus/work/primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.scheme.bed
       md5sum: d5ad850f8c610dc45162957ab84530d6
     - path: miniwdl_run/call-consensus_qc/command
-      md5sum: 1c60393834c06e6dbf0654855e245900
+      md5sum: 8766aa99bf4cb3e4a1d7bb7a06439213
     - path: miniwdl_run/call-consensus_qc/inputs.json
       contains: ["assembly_fasta", "medaka"]
     - path: miniwdl_run/call-consensus_qc/outputs.json

--- a/tests/workflows/test_clearlabs.yml
+++ b/tests/workflows/test_clearlabs.yml
@@ -407,7 +407,7 @@
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/clearlabs.stats.txt
       md5sum: 6ad40bcca227c92fdfec23fe9a03c344
     - path: miniwdl_run/call-vadr/command
-      md5sum: 348e243c63b2ed45dfc5204e2cf6ccb9
+      md5sum: bf01367b311b76c9127738edce9f0dc8
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json
@@ -440,7 +440,7 @@
     - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.fail.tbl
       md5sum: 26200881fe2b49458c1eb4e4be549eea
     - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.filelist
-      md5sum: c228d6d991ea1f7ac4565b719523415f
+      md5sum: faf9ce62325894dd5415c046b2ad7e3a
     - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.ftr
       md5sum: f42dbcedf3456c0af772f9f6edabed1f
     - path: miniwdl_run/call-vadr/work/clearlabs.medaka.consensus/clearlabs.medaka.consensus.vadr.log
@@ -478,7 +478,7 @@
     - path: miniwdl_run//wdl/tasks/quality_control/task_fastq_scan.wdl
       md5sum: 7584c321243c18b70b7f18e91fa019df
     - path: miniwdl_run/wdl/tasks/task_ncbi.wdl
-      md5sum: e08ed21046a757fe4a3f1335a48e18d3
+      md5sum: fb25b730a30d82027c33b15a312dd634
     - path: miniwdl_run/wdl/tasks/task_ont_medaka.wdl
       md5sum: 702db7d86d5120805e4aee0067365ee6
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
@@ -490,7 +490,7 @@
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: 111f18669c9cf8b3a49eb29a33d436ae
     - path: miniwdl_run/wdl/workflows/wf_theiacov_clearlabs.wdl
-      md5sum: a30be76dcbb93539b34daf4a0dd6eeb3
+      md5sum: 3d4a65aa7f280908aab9674a8711ebe1
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_clearlabs", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/tests/workflows/test_illumina_pe.yml
+++ b/tests/workflows/test_illumina_pe.yml
@@ -60,7 +60,7 @@
       md5sum: 6923b89d36bc66e1cdfabfd1dedbea71
     - path: miniwdl_run/call-consensus/work/_miniwdl_inputs/0/SRR13687078.primertrim.sorted.bam
     - path: miniwdl_run/call-consensus_qc/command
-      md5sum: e081fb53c7da2c0a92d692230c6a73aa
+      md5sum: f8324f3be110ddffe4ab83929b647b9a
     - path: miniwdl_run/call-consensus_qc/inputs.json
       contains: ["assembly_fasta", "SRR13687078"]
     - path: miniwdl_run/call-consensus_qc/outputs.json
@@ -498,7 +498,7 @@
       md5sum: 53be85d2ed9fa57ab45424fe071a6672
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/SRR13687078.primertrim.sorted.bam
     - path: miniwdl_run/call-vadr/command
-      md5sum: d4943d5100c490fed7c22fd25d3d44ad
+      md5sum: 1fb9a4d1d7f341cce203729fc6e1f1f4
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "SRR13687078"]
     - path: miniwdl_run/call-vadr/outputs.json
@@ -529,7 +529,7 @@
     - path: miniwdl_run/call-vadr/work/SRR13687078.ivar.consensus/SRR13687078.ivar.consensus.vadr.fail.tbl
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-vadr/work/SRR13687078.ivar.consensus/SRR13687078.ivar.consensus.vadr.filelist
-      md5sum: 9a8999e7f4f6744435e575830dbed3b7
+      md5sum: 7715c2ddbc13d7f5b4dc3e016e7771a9
     - path: miniwdl_run/call-vadr/work/SRR13687078.ivar.consensus/SRR13687078.ivar.consensus.vadr.ftr
       md5sum: c12de7e5b1f117039bbfd2000b2ce8ec
     - path: miniwdl_run/call-vadr/work/SRR13687078.ivar.consensus/SRR13687078.ivar.consensus.vadr.log
@@ -588,7 +588,7 @@
     - path: miniwdl_run/wdl/tasks/quality_control/task_assembly_metrics.wdl
       md5sum: a5bd00f53895afd62bf216b314c488eb
     - path: miniwdl_run/wdl/tasks/quality_control/task_consensus_qc.wdl
-      md5sum: b250698371ecadca92d37233723837d0
+      md5sum: 9885debe1ad812ca22094c462e229281
     - path: miniwdl_run/wdl/tasks/quality_control/task_fastq_scan.wdl
       md5sum: 7584c321243c18b70b7f18e91fa019df
     - path: miniwdl_run/wdl/tasks/task_alignment.wdl
@@ -596,7 +596,7 @@
     - path: miniwdl_run/wdl/tasks/task_consensus_call.wdl
       md5sum: 9bf42b12fa4d707cce63570fd30449b7
     - path: miniwdl_run/wdl/tasks/task_ncbi.wdl
-      md5sum: e08ed21046a757fe4a3f1335a48e18d3
+      md5sum: fb25b730a30d82027c33b15a312dd634
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
       md5sum: d4b48760e66ffc28faead23aaeb54ae5
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
@@ -608,7 +608,7 @@
     - path: miniwdl_run/wdl/workflows/wf_read_QC_trim.wdl
       md5sum: 54dc94bef589bace0680e55d17cf4a9c
     - path: miniwdl_run/wdl/workflows/wf_theiacov_illumina_pe.wdl
-      md5sum: 459f1769fd6d3d2453d9c48d9abb7358
+      md5sum: cb3cf43feaf19e9ebd44d128b2084712
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_illumina_pe", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/tests/workflows/test_illumina_se.yml
+++ b/tests/workflows/test_illumina_se.yml
@@ -59,7 +59,7 @@
       md5sum: 03c5ecf22fdfdb6b240ac3880281a056
     - path: miniwdl_run/call-consensus/work/_miniwdl_inputs/0/ERR6319327.primertrim.sorted.bam
     - path: miniwdl_run/call-consensus_qc/command
-      md5sum: a86fa5989de7ceab82674679e3d1a5ad
+      md5sum: 82fe0ec5bcb962c1f971b97580331003
     - path: miniwdl_run/call-consensus_qc/inputs.json
       contains: ["assembly_fasta", "ERR6319327"]
     - path: miniwdl_run/call-consensus_qc/outputs.json
@@ -408,7 +408,7 @@
       md5sum: 53be85d2ed9fa57ab45424fe071a6672
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/_miniwdl_inputs/0/ERR6319327.primertrim.sorted.bam
     - path: miniwdl_run/call-vadr/command
-      md5sum: 06c101b7245132b90b9dc64c11ffab4a
+      md5sum: c52939e16c145f7a9027c9a435d952ca
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "ERR6319327"]
     - path: miniwdl_run/call-vadr/outputs.json
@@ -437,7 +437,7 @@
     - path: miniwdl_run/call-vadr/work/ERR6319327.ivar.consensus/ERR6319327.ivar.consensus.vadr.fail.tbl
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-vadr/work/ERR6319327.ivar.consensus/ERR6319327.ivar.consensus.vadr.filelist
-      md5sum: 8dad61c981370ecc661e3f5f3156d7e6
+      md5sum: 9dbf808eeeda14c35d9e827ad5bf5fc0
     - path: miniwdl_run/call-vadr/work/ERR6319327.ivar.consensus/ERR6319327.ivar.consensus.vadr.ftr
       md5sum: a6695b940958e76e8d3a6fa24a1e04a2
     - path: miniwdl_run/call-vadr/work/ERR6319327.ivar.consensus/ERR6319327.ivar.consensus.vadr.log
@@ -498,7 +498,7 @@
     - path: miniwdl_run/wdl/tasks/quality_control/task_assembly_metrics.wdl
       md5sum: a5bd00f53895afd62bf216b314c488eb
     - path: miniwdl_run/wdl/tasks/quality_control/task_consensus_qc.wdl
-      md5sum: b250698371ecadca92d37233723837d0
+      md5sum: 9885debe1ad812ca22094c462e229281
     - path: miniwdl_run/wdl/tasks/quality_control/task_fastq_scan.wdl
       md5sum: 7584c321243c18b70b7f18e91fa019df
     - path: miniwdl_run/wdl/tasks/task_alignment.wdl
@@ -506,7 +506,7 @@
     - path: miniwdl_run/wdl/tasks/task_consensus_call.wdl
       md5sum: 9bf42b12fa4d707cce63570fd30449b7
     - path: miniwdl_run/wdl/tasks/task_ncbi.wdl
-      md5sum: e08ed21046a757fe4a3f1335a48e18d3
+      md5sum: fb25b730a30d82027c33b15a312dd634
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
       md5sum: d4b48760e66ffc28faead23aaeb54ae5
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
@@ -518,7 +518,7 @@
     - path: miniwdl_run/wdl/workflows/wf_read_QC_trim_se.wdl
       md5sum: ab63cb95ae3707ce7ff10637bc0b0be6
     - path: miniwdl_run/wdl/workflows/wf_theiacov_illumina_se.wdl
-      md5sum: 5bbe049a5a25c6058ae8fbf93fe2dacd
+      md5sum: cd51fb2e562e98fcab9dfd5c092dda21
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_illumina_se", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/tests/workflows/test_ont.yml
+++ b/tests/workflows/test_ont.yml
@@ -83,7 +83,7 @@
     - path: miniwdl_run/call-consensus/work/primer-schemes/SARS-CoV-2/Vuser/SARS-CoV-2.scheme.bed
       md5sum: d5ad850f8c610dc45162957ab84530d6
     - path: miniwdl_run/call-consensus_qc/command
-      md5sum: 6e6639b2d1e92ddabfb21c99a34cccda
+      md5sum: cfcd8293a3ae57748922632b50229aab
     - path: miniwdl_run/call-consensus_qc/inputs.json
       contains: ["assembly_fasta", "medaka"]
     - path: miniwdl_run/call-consensus_qc/outputs.json
@@ -415,7 +415,7 @@
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/ont.flagstat.txt
     - path: miniwdl_run/call-stats_n_coverage_primtrim/work/ont.stats.txt
     - path: miniwdl_run/call-vadr/command
-      md5sum: 5f55c6c522507430aa49ef596a26802b
+      md5sum: b93f323b8c827a01ea2e83c2d215c16d
     - path: miniwdl_run/call-vadr/inputs.json
       contains: ["assembly_length_unambiguous", "genome_fasta", "fasta"]
     - path: miniwdl_run/call-vadr/outputs.json
@@ -448,7 +448,7 @@
     - path: miniwdl_run/call-vadr/work/ont.medaka.consensus/ont.medaka.consensus.vadr.fail.tbl
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-vadr/work/ont.medaka.consensus/ont.medaka.consensus.vadr.filelist
-      md5sum: 0c278bce4a4274d8bb270a68627e1665
+      md5sum: 3d165e2764d6c19dc3187b8719086898
     - path: miniwdl_run/call-vadr/work/ont.medaka.consensus/ont.medaka.consensus.vadr.ftr
       md5sum: bb7dbd4e05d41b48710ceddec48346e6
     - path: miniwdl_run/call-vadr/work/ont.medaka.consensus/ont.medaka.consensus.vadr.log
@@ -482,11 +482,11 @@
     - path: miniwdl_run/wdl/tasks/quality_control/task_assembly_metrics.wdl
       md5sum: a5bd00f53895afd62bf216b314c488eb
     - path: miniwdl_run/wdl/tasks/quality_control/task_consensus_qc.wdl
-      md5sum: b250698371ecadca92d37233723837d0
+      md5sum: 9885debe1ad812ca22094c462e229281
     - path: miniwdl_run/wdl/tasks/quality_control/task_fastq_scan.wdl
       md5sum: 7584c321243c18b70b7f18e91fa019df
     - path: miniwdl_run/wdl/tasks/task_ncbi.wdl
-      md5sum: e08ed21046a757fe4a3f1335a48e18d3
+      md5sum: fb25b730a30d82027c33b15a312dd634
     - path: miniwdl_run/wdl/tasks/task_ont_medaka.wdl
       md5sum: 702db7d86d5120805e4aee0067365ee6
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
@@ -498,7 +498,7 @@
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: 111f18669c9cf8b3a49eb29a33d436ae
     - path: miniwdl_run/wdl/workflows/wf_theiacov_ont.wdl
-      md5sum: d2087ccfc0a800c83eaea3557efb7282
+      md5sum: 34c2fae95aebd0efc850df4fce908026
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_ont", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/workflows/wf_theiacov_clearlabs.wdl
+++ b/workflows/wf_theiacov_clearlabs.wdl
@@ -188,5 +188,6 @@ workflow theiacov_clearlabs {
     File?  vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts
     String? vadr_docker = vadr.vadr_docker
+    File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
   }
 }

--- a/workflows/wf_theiacov_fasta.wdl
+++ b/workflows/wf_theiacov_fasta.wdl
@@ -93,5 +93,6 @@ workflow theiacov_fasta {
     File?  vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts
     String? vadr_docker = vadr.vadr_docker
+    File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
   }
 }

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -207,5 +207,6 @@ workflow theiacov_illumina_pe {
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts
     String? vadr_docker = vadr.vadr_docker
+    File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
   }
 }

--- a/workflows/wf_theiacov_illumina_se.wdl
+++ b/workflows/wf_theiacov_illumina_se.wdl
@@ -196,5 +196,6 @@ workflow theiacov_illumina_se {
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts
     String? vadr_docker = vadr.vadr_docker
+    File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
   }
 }

--- a/workflows/wf_theiacov_ont.wdl
+++ b/workflows/wf_theiacov_ont.wdl
@@ -197,5 +197,6 @@ workflow theiacov_ont {
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts
     String? vadr_docker = vadr.vadr_docker
+    File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
   }
 }

--- a/workflows/wf_vadr_update.wdl
+++ b/workflows/wf_vadr_update.wdl
@@ -7,11 +7,13 @@ workflow vadr_update {
   input {
     File genome_fasta
     String docker
+    Int assembly_length_unambiguous
   }
   call ncbi.vadr {
     input:
       genome_fasta = genome_fasta,
-      docker = docker
+      docker = docker,
+      assembly_length_unambiguous = assembly_length_unambiguous
   }
   call versioning.version_capture{
     input:
@@ -24,5 +26,6 @@ workflow vadr_update {
     File? vadr_alerts_list = vadr.alerts_list
     String vadr_num_alerts = vadr.num_alerts
     String vadr_docker = vadr.vadr_docker
+    File? vadr_fastas_zip_archive = vadr.vadr_fastas_zip_archive
   }
 }


### PR DESCRIPTION
~~Setting as a draft until I complete testing on Terra.~~ Ready for review

Motivation for PR - one lab requested having access to a nucleotide FASTA file specific to the S gene for SARS-CoV-2. 

VADR has the ability to produce feature-specific FASTA files when adding this flag `--out_allfasta` to the VADR command `v-annotate.pl`, so this will produce individual FASTA files for each "feature" predicted/annotated by VADR. 

This PR does the following:

- Adds `--out_allfasta` to default `vadr_opts` input parameter
- alters VADR task to produce a `.zip` archive containing all FASTA files produced by VADR (all files ending in `.fa` in VADR output directory)
- VADR task now outputs a new file: `vadr_fastas_zip_archive`
- Adds new 1 new output ^ to all TheiaCov_ workflows (FASTA, ONT, ClearLabs, Illumina PE and SE, VADR_Update)
- VADR_Update workflow has been altered to include a required input parameter `assembly_length_unambiguous`. Not sure how it functioned without the input previously 🤷 


I opted for the `.zip` file format since these can be extracted/decompressed natively on Windows (no need for 3rd party software like 7-zip). Much easier than extracting from `.tar.gz` files on Windows.