### PR TITLE
Add optional arguments input to trimmomatic task and add fastp task

### DIFF
--- a/tasks/task_read_clean.wdl
+++ b/tasks/task_read_clean.wdl
@@ -237,6 +237,90 @@ task trimmomatic_se {
   }
 }
 
+task fastp {
+  input {
+    File read1
+    File read2
+    String samplename
+    String docker = "quay.io/staphb/fastp:0.23.2"
+    Int? fastp_minlen = 75
+    Int? fastp_window_size=4
+    Int? fastp_quality_trim_score=30
+    # adapter trimming and quality filtering are enabled by default, the flags below disable these functions to match trimmomatic
+    String? fastp_args = "--disable_adapter_trimming --disable_quality_filtering --disable_trim_poly_g --dont_eval_duplication"
+    Int? threads = 4
+  }
+  command <<<
+    # date 
+    date | tee DATE
+
+    fastp \
+    --in1 ~{read1} --in2 ~{read2} \
+    --out1 ~{samplename}_1P.fastq.gz --out2 ~{samplename}_2P.fastq.gz \
+    --cut_right --cut_window_size ~{fastp_window_size} --cut_mean_quality ~{fastp_quality_trim_score} \
+    --length_required ~{fastp_minlen} \
+    --thread ~{threads} \
+    ~{fastp_args} \
+    --html ~{samplename}_fastp.html --json ~{samplename}_fastp.json
+  >>>
+  output {
+    File read1_trimmed = "~{samplename}_1P.fastq.gz"
+    File read2_trimmed = "~{samplename}_2P.fastq.gz"
+    File fastp_stats = "~{samplename}_fastp.html"
+    String version = "~{docker}"
+    String pipeline_date = read_string("DATE")
+  }
+  runtime {
+    docker: "~{docker}"
+    memory: "8 GB"
+    cpu: 4
+    disks: "local-disk 100 SSD"
+    preemptible: 0
+    maxRetries: 3
+  }
+}
+
+task fastp_se {
+  input {
+    File read1
+    String samplename
+    String docker = "quay.io/staphb/fastp:0.23.2"
+    Int? fastp_minlen = 75
+    Int? fastp_window_size=4
+    Int? fastp_quality_trim_score=30
+    Int? threads = 4
+    # adapter trimming and quality filtering are enabled by default, the flags below disable these functions
+    String? fastp_params = "--disable_adapter_trimming --disable_quality_filtering"
+  }
+  command <<<
+    # date 
+    date | tee DATE
+
+    fastp \
+    --in1 ~{read1} \
+    --out1 ~{samplename}_1P.fastq.gz \
+    --cut_right --cut_window_size ~{fastp_window_size} --cut_mean_quality ~{fastp_quality_trim_score} \
+    --length_required ~{fastp_minlen} \
+    --thread ~{threads} \
+    ~{fastp_params} \
+    --html ~{samplename}_fastp.html --json ~{samplename}_fastp.json
+  >>>
+  output {
+    File read1_trimmed = "~{samplename}_1P.fastq.gz"
+    File fastp_stats = "~{samplename}_fastp.html"
+    String version = "~{docker}"
+    String pipeline_date = read_string("DATE")
+  }
+  runtime {
+    docker: "~{docker}"
+    memory: "8 GB"
+    cpu: 4
+    disks: "local-disk 100 SSD"
+    preemptible: 0
+    maxRetries: 3
+  }
+}
+
 task bbduk {
   input {
     File read1_trimmed

--- a/tasks/task_read_clean.wdl
+++ b/tasks/task_read_clean.wdl
@@ -164,6 +164,7 @@ task trimmomatic {
     Int? trimmomatic_window_size=4
     Int? trimmomatic_quality_trim_score=30
     Int? threads = 4
+    String? trimmomatic_args
   }
   command <<<
     # date and version control
@@ -171,6 +172,7 @@ task trimmomatic {
     trimmomatic -version > VERSION && sed -i -e 's/^/Trimmomatic /' VERSION
 
     trimmomatic PE \
+    ~{trimmomatic_args} \
     -threads ~{threads} \
     ~{read1} ~{read2} \
     -baseout ~{samplename}.fastq.gz \
@@ -204,6 +206,7 @@ task trimmomatic_se {
     Int? trimmomatic_window_size = 4
     Int? trimmomatic_quality_trim_score = 30
     Int? threads = 4
+    String? trimmomatic_args
   }
   command <<<
     # date and version control
@@ -211,6 +214,7 @@ task trimmomatic_se {
     trimmomatic -version > VERSION && sed -i -e 's/^/Trimmomatic /' VERSION
 
     trimmomatic SE \
+    ~{trimmomatic_args} \
     -threads ~{threads} \
     ~{read1} \
     ~{samplename}_trimmed.fastq.gz \

--- a/workflows/wf_read_QC_trim.wdl
+++ b/workflows/wf_read_QC_trim.wdl
@@ -17,6 +17,7 @@ workflow read_QC_trim {
     Int? trimmomatic_window_size = 4
     Int bbduk_mem = 8
     String? target_org
+    String? trim_args
   }
   call read_clean.ncbi_scrub_pe {
     input:
@@ -31,7 +32,8 @@ workflow read_QC_trim {
       read2 = ncbi_scrub_pe.read2_dehosted,
       trimmomatic_minlen = trimmomatic_minlen,
       trimmomatic_quality_trim_score = trimmomatic_quality_trim_score,
-      trimmomatic_window_size = trimmomatic_window_size
+      trimmomatic_window_size = trimmomatic_window_size,
+      trimmomatic_args = trim_args
   }
   call read_clean.bbduk {
     input:

--- a/workflows/wf_read_QC_trim_se.wdl
+++ b/workflows/wf_read_QC_trim_se.wdl
@@ -16,6 +16,7 @@ workflow read_QC_trim {
     Int? trimmomatic_window_size = 4
     Int  bbduk_mem = 8
     String? target_org
+    String? trim_args
   }
 # Commented out as NCBI SCRUB not currently compatible with 75bp SE data used in SC2 sequencing
 #  call read_clean.ncbi_scrub_se {
@@ -29,7 +30,8 @@ workflow read_QC_trim {
       read1 = read1_raw,
       trimmomatic_minlen = trimmomatic_minlen,
       trimmomatic_quality_trim_score = trimmomatic_quality_trim_score,
-      trimmomatic_window_size = trimmomatic_window_size
+      trimmomatic_window_size = trimmomatic_window_size,
+      trimmomatic_args = trim_args
   }
   call read_clean.bbduk_se {
     input:


### PR DESCRIPTION
- This PR adds an optional input (trimmomatic_args) to the trimmomatic and trimmomatic_se tasks (tasks/task_read_clean.wdl) so that additional arguments can be appended to the trimmomatic command. 
- For example, providing "phred33" for this input will specify that Phred33 is the quality encoding for the sequencing data to be analyzed. By default, no arguments are provided.
- This PR also adds this input to workflows/wf_read_QC_trim.wdl and workflows/wf_read_QC_trim_se.wdl
- This PR also adds a task for running fastp (https://github.com/OpenGene/fastp), but does not incorporate it into any workflows

- This branch has been tested on:
-       10 samples with "-phred33" added as an optional input
-       10 samples with no optional input provided to verify that previous results are unchanged