### PR TITLE
adds support for running VADR on WNV samples

### DIFF
--- a/tests/workflows/test_illumina_pe.yml
+++ b/tests/workflows/test_illumina_pe.yml
@@ -608,7 +608,7 @@
     - path: miniwdl_run/wdl/workflows/wf_read_QC_trim.wdl
       md5sum: 9769f7ff548537ed7d36c5d0df445416
     - path: miniwdl_run/wdl/workflows/wf_theiacov_illumina_pe.wdl
-      md5sum: e22dfe6315a07d7d17b4b12ba5a71c92
+      md5sum: 649ddd2b110c6c3ae0a12d429f6f3306
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_illumina_pe", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/tests/workflows/test_illumina_se.yml
+++ b/tests/workflows/test_illumina_se.yml
@@ -518,7 +518,7 @@
     - path: miniwdl_run/wdl/workflows/wf_read_QC_trim_se.wdl
       md5sum: eb4170a3da9d95720b5403dd3d5e5d87
     - path: miniwdl_run/wdl/workflows/wf_theiacov_illumina_se.wdl
-      md5sum: 6daa338cbd4821292780d80d659b75d4
+      md5sum: 79370384d920d18fb8687c3218f2ccdc
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_illumina_se", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/tests/workflows/test_ont.yml
+++ b/tests/workflows/test_ont.yml
@@ -498,7 +498,7 @@
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
       md5sum: 111f18669c9cf8b3a49eb29a33d436ae
     - path: miniwdl_run/wdl/workflows/wf_theiacov_ont.wdl
-      md5sum: 4904a2e5b0e179f2f82e989033dcd08e
+      md5sum: d19f035e33da9f0d1a5116a8730bc455
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_ont", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/workflows/wf_theiacov_fasta.wdl
+++ b/workflows/wf_theiacov_fasta.wdl
@@ -34,6 +34,9 @@ workflow theiacov_fasta {
   if (organism == "MPXV") {
     # MPXV specific tasks
   }
+  if (organism == "WNV") {
+    # WNV specific tasks (none yet, just adding as placeholder for future)
+  }
   if (organism == "MPXV" || organism == "sars-cov-2"){
     # tasks specific to either MPXV or sars-cov-2 
     call taxon_ID.nextclade_one_sample {
@@ -47,6 +50,9 @@ workflow theiacov_fasta {
       input:
       nextclade_tsv = nextclade_one_sample.nextclade_tsv
     }
+  }
+  if (organism == "MPXV" || organism == "sars-cov-2" || organism == "WNV"){ 
+    # tasks specific to MPXV, sars-cov-2, and WNV
     call ncbi.vadr {
       input:
         genome_fasta = assembly_fasta,

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -99,6 +99,9 @@ workflow theiacov_illumina_pe {
   if (organism == "MPXV") {
     # MPXV specific tasks
   }
+  if (organism == "WNV") {
+    # WNV specific tasks (none yet, just adding as placeholder for future)
+  }
   if (organism == "MPXV" || organism == "sars-cov-2"){ 
     # tasks specific to either MPXV or sars-cov-2
     call taxon_ID.nextclade_one_sample {
@@ -112,6 +115,9 @@ workflow theiacov_illumina_pe {
       input:
       nextclade_tsv = nextclade_one_sample.nextclade_tsv
     }
+  }
+  if (organism == "MPXV" || organism == "sars-cov-2" || organism == "WNV"){ 
+    # tasks specific to MPXV, sars-cov-2, and WNV
     call ncbi.vadr {
       input:
         genome_fasta = consensus.consensus_seq,

--- a/workflows/wf_theiacov_illumina_se.wdl
+++ b/workflows/wf_theiacov_illumina_se.wdl
@@ -97,6 +97,9 @@ workflow theiacov_illumina_se {
   if (organism == "MPXV") {
     # MPXV specific tasks
   }
+  if (organism == "WNV") {
+    # WNV specific tasks (none yet, just adding as placeholder for future)
+  }
   if (organism == "MPXV" || organism == "sars-cov-2"){
     # tasks specific to either MPXV or sars-cov-2
     call taxon_ID.nextclade_one_sample {
@@ -110,6 +113,9 @@ workflow theiacov_illumina_se {
       input:
       nextclade_tsv = nextclade_one_sample.nextclade_tsv
     }
+  }
+  if (organism == "MPXV" || organism == "sars-cov-2" || organism == "WNV"){ 
+    # tasks specific to MPXV, sars-cov-2, and WNV
     call ncbi.vadr {
       input:
         genome_fasta = consensus.consensus_seq,

--- a/workflows/wf_theiacov_ont.wdl
+++ b/workflows/wf_theiacov_ont.wdl
@@ -102,6 +102,9 @@ workflow theiacov_ont {
   if (organism == "MPXV") {
     # MPXV specific tasks
   }
+  if (organism == "WNV") {
+    # WNV specific tasks (none yet, just adding as placeholder for future)
+  }
   if (organism == "MPXV" || organism == "sars-cov-2"){ 
     # tasks specific to either MPXV or sars-cov-2
     call taxon_ID.nextclade_one_sample {
@@ -115,6 +118,9 @@ workflow theiacov_ont {
       input:
       nextclade_tsv = nextclade_one_sample.nextclade_tsv
     }
+   }
+  if (organism == "MPXV" || organism == "sars-cov-2" || organism == "WNV"){ 
+    # tasks specific to MPXV, sars-cov-2, and WNV
     call ncbi.vadr {
       input:
         genome_fasta = consensus.consensus_seq,


### PR DESCRIPTION
This PR adds support for running VADR on West Nile Virus genomes when the user specifies `WNV` as the `organism` input string parameter. Merging this will resolve issue #180 

Applies to these workflows:
- TheiaCov_Illumina_PE
- TheiaCov_Illumina_SE
- TheiaCov_ONT
- TheiaCov_FASTA 

No support for WNV on ClearLabs, so ignoring TheiaCov_ClearLabs for now.

Required input parameters (will need to be set in organism-specific input JSONs for Terra):
- `theiacov_illumina_pe.organism == "WNV"`
- `read_QC_trim.target_org == "West Nile virus"` (for Kraken2 string searching)
- `vadr.vadr_opts == "--mkey flavi --mdir /opt/vadr/vadr-models-flavi/ --nomisc --noprotid --out_allfasta"`
- `vadr.skip_length == 3000` - default is 10000 which is almost the genome length of WNV. 3000 seems sensisble as a very loose threshold to allow even poor quality genomes to be annotated w VADR.

~~Setting as a draft until I finish testing in Terra~~

Successfully tested ILMN PE, ILMN SE, and FASTA workflows in Terra. Don't have any test ONT data, but given code changes are identical between workflows, it should work fine if folks choose to sequence WNV on an ONT platform


