### PR TITLE
Ensure bbduk outputs are ordered

### DIFF
--- a/tasks/task_abricate_flu.wdl
+++ b/tasks/task_abricate_flu.wdl
@@ -14,6 +14,7 @@ task abricate_flu {
     Int cpu = 2
     Int memory = 4
     String docker = "staphb/abricate:1.0.1-insaflu-220727"
+    Int disk_size = 100
   }
   command <<<
     date | tee DATE    
@@ -71,7 +72,8 @@ task abricate_flu {
       docker: "~{docker}"
       memory: "~{memory} GB"
       cpu: cpu
-      disks: "local-disk 100 SSD"
+      disks:  "local-disk " + disk_size + " SSD"
+      disk: disk_size + " GB"
       preemptible:  0
   }
 }

--- a/tasks/task_irma.wdl
+++ b/tasks/task_irma.wdl
@@ -9,8 +9,9 @@ task irma {
     String irma_module = "FLU"
     String read_basename = basename(read1)
     String docker = "quay.io/staphb/irma:1.0.3"
-	Int memory = 8
-	Int cpu = 4
+    Int memory = 8
+    Int cpu = 4
+    Int disk_size = 100
   }
   command <<<
     date | tee DATE
@@ -92,7 +93,9 @@ task irma {
     docker: "~{docker}"
     memory: "~{memory} GB"
     cpu: cpu
-    disks: "local-disk 100 SSD"
+    disks:  "local-disk " + disk_size + " SSD"
+    disk: disk_size + " GB"
+    maxRetries: 3
     preemptible:  0
   }
 }

--- a/tasks/task_mercury_file_wrangling.wdl
+++ b/tasks/task_mercury_file_wrangling.wdl
@@ -14,6 +14,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
     Int number_N_threshold = 5000 # only for SC2
     Boolean skip_county
     Boolean skip_ncbi
+    Int disk_size = 100
   }
   command <<<
     # when running on terra, comment out all input_table mentions
@@ -463,7 +464,8 @@ task sm_metadata_wrangling { # the sm stands for supermassive
     docker: "broadinstitute/terra-tools:tqdm"
     memory: "8 GB"
     cpu: 4
-    disks: "local-disk 100 SSD"
+    disks:  "local-disk " + disk_size + " SSD"
+    disk: disk_size + " GB"
     preemptible: 0
   }
 }
@@ -474,6 +476,7 @@ task trim_genbank_fastas {
     String output_name
     Int minlen = 50
     Int maxlen = 30000
+    Int disk_size = 100
   }
   command <<<
     # remove terminal ambiguous nucleotides
@@ -490,7 +493,8 @@ task trim_genbank_fastas {
     docker: "quay.io/staphb/vadr:1.3"
     memory: "1 GB"
     cpu: 1    
-    disks: "local-disk 25 SSD"
+    disks:  "local-disk " + disk_size + " SSD"
+    disk: disk_size + " GB"
     preemptible: 0
     maxRetries: 3
   }
@@ -504,6 +508,7 @@ task table2asn {
     File bankit_fasta
     File bankit_metadata
     String output_name
+    Int disk_size = 100
   }
   command <<<
     # using this echo statement so the fasta file doesn't have a wiggly line
@@ -529,7 +534,8 @@ task table2asn {
     docker: "staphb/ncbi-table2asn:1.26.678"
     memory: "1 GB"
     cpu: 1
-    disks: "local-disk 25 SSD"
+    disks:  "local-disk " + disk_size + " SSD"
+    disk: disk_size + " GB"
     preemptible: 0
     maxRetries: 3
     continueOnReturnCode: [0, 2]

--- a/tasks/task_read_clean.wdl
+++ b/tasks/task_read_clean.wdl
@@ -425,9 +425,9 @@ task bbduk_se {
       phix_fasta="/bbmap/resources/phix174_ill.ref.fa.gz"
     fi
 
-    bbduk.sh in1=~{read1_trimmed} out1=~{samplename}.rmadpt_1.fastq.gz ref=${adapter_fasta} stats=~{samplename}.adapters.stats.txt ktrim=r k=23 mink=11 hdist=1 tpe tbo
+    bbduk.sh in1=~{read1_trimmed} out1=~{samplename}.rmadpt_1.fastq.gz ref=${adapter_fasta} stats=~{samplename}.adapters.stats.txt ktrim=r k=23 mink=11 hdist=1 tpe tbo ordered=t
 
-    bbduk.sh in1=~{read1_trimmed} out1=~{samplename}_1.clean.fastq.gz outm=~{samplename}.matched_phix.fq ref=${phix_fasta} k=31 hdist=1 stats=~{samplename}.phix.stats.txt
+    bbduk.sh in1=~{read1_trimmed} out1=~{samplename}_1.clean.fastq.gz outm=~{samplename}.matched_phix.fq ref=${phix_fasta} k=31 hdist=1 stats=~{samplename}.phix.stats.txt ordered=t
   >>>
   output {
     File read1_clean = "${samplename}_1.clean.fastq.gz"

--- a/tasks/task_read_clean.wdl
+++ b/tasks/task_read_clean.wdl
@@ -370,9 +370,9 @@ task bbduk {
 
     repair.sh in1=~{read1_trimmed} in2=~{read2_trimmed} out1=~{samplename}.paired_1.fastq.gz out2=~{samplename}.paired_2.fastq.gz
 
-    bbduk.sh in1=~{samplename}.paired_1.fastq.gz in2=~{samplename}.paired_2.fastq.gz out1=~{samplename}.rmadpt_1.fastq.gz out2=~{samplename}.rmadpt_2.fastq.gz ref=${adapter_fasta} stats=~{samplename}.adapters.stats.txt ktrim=r k=23 mink=11 hdist=1 tpe tbo
+    bbduk.sh in1=~{samplename}.paired_1.fastq.gz in2=~{samplename}.paired_2.fastq.gz out1=~{samplename}.rmadpt_1.fastq.gz out2=~{samplename}.rmadpt_2.fastq.gz ref=${adapter_fasta} stats=~{samplename}.adapters.stats.txt ktrim=r k=23 mink=11 hdist=1 tpe tbo ordered=t
 
-    bbduk.sh in1=~{samplename}.rmadpt_1.fastq.gz in2=~{samplename}.rmadpt_2.fastq.gz out1=~{samplename}_1.clean.fastq.gz out2=~{samplename}_2.clean.fastq.gz outm=~{samplename}.matched_phix.fq ref=${phix_fasta} k=31 hdist=1 stats=~{samplename}.phix.stats.txt
+    bbduk.sh in1=~{samplename}.rmadpt_1.fastq.gz in2=~{samplename}.rmadpt_2.fastq.gz out1=~{samplename}_1.clean.fastq.gz out2=~{samplename}_2.clean.fastq.gz outm=~{samplename}.matched_phix.fq ref=${phix_fasta} k=31 hdist=1 stats=~{samplename}.phix.stats.txt ordered=t
   >>>
   output {
     File read1_clean = "${samplename}_1.clean.fastq.gz"

--- a/tests/workflows/test_clearlabs.yml
+++ b/tests/workflows/test_clearlabs.yml
@@ -482,7 +482,7 @@
     - path: miniwdl_run/wdl/tasks/task_ont_medaka.wdl
       md5sum: 9683dd0601393ad8d91fe3a27c311fd0
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
-      md5sum: 03bc121a71bbb93f0da0503aee681b2a
+      md5sum: 82081b9f98af840a387e335e3dc6f5ee
     - path: miniwdl_run//wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl

--- a/tests/workflows/test_clearlabs.yml
+++ b/tests/workflows/test_clearlabs.yml
@@ -482,7 +482,7 @@
     - path: miniwdl_run/wdl/tasks/task_ont_medaka.wdl
       md5sum: 9683dd0601393ad8d91fe3a27c311fd0
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
-      md5sum: 557832879a573e1493d12947df99d5db
+      md5sum: 03bc121a71bbb93f0da0503aee681b2a
     - path: miniwdl_run//wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl

--- a/tests/workflows/test_illumina_pe.yml
+++ b/tests/workflows/test_illumina_pe.yml
@@ -225,7 +225,7 @@
     - path: miniwdl_run/call-primer_trim/work/_miniwdl_inputs/0/artic-v3.primers.bed
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-read_QC_trim/call-bbduk/command
-      md5sum: fc8fca468562a8ac9a708c17084dc914
+      md5sum: 35bf0212e172f068646ff9474bfbfbdc
     - path: miniwdl_run/call-read_QC_trim/call-bbduk/inputs.json
       contains: ["memory", "read1_trimmed", "SRR13687078"]
     - path: miniwdl_run/call-read_QC_trim/call-bbduk/outputs.json
@@ -598,7 +598,7 @@
     - path: miniwdl_run/wdl/tasks/task_ncbi.wdl
       md5sum: 6ce92b1d9e2ea30352fce2be354a1086
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
-      md5sum: 557832879a573e1493d12947df99d5db
+      md5sum: 03bc121a71bbb93f0da0503aee681b2a
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl
@@ -608,7 +608,7 @@
     - path: miniwdl_run/wdl/workflows/wf_read_QC_trim.wdl
       md5sum: 9769f7ff548537ed7d36c5d0df445416
     - path: miniwdl_run/wdl/workflows/wf_theiacov_illumina_pe.wdl
-      md5sum: e1291b68fff8310b4b85ee6c7d6fd462
+      md5sum: 9efc4b697aa5b57d80146a8c45eba447
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_illumina_pe", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/tests/workflows/test_illumina_pe.yml
+++ b/tests/workflows/test_illumina_pe.yml
@@ -598,7 +598,7 @@
     - path: miniwdl_run/wdl/tasks/task_ncbi.wdl
       md5sum: 6ce92b1d9e2ea30352fce2be354a1086
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
-      md5sum: 03bc121a71bbb93f0da0503aee681b2a
+      md5sum: 82081b9f98af840a387e335e3dc6f5ee
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl

--- a/tests/workflows/test_illumina_se.yml
+++ b/tests/workflows/test_illumina_se.yml
@@ -508,7 +508,7 @@
     - path: miniwdl_run/wdl/tasks/task_ncbi.wdl
       md5sum: 6ce92b1d9e2ea30352fce2be354a1086
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
-      md5sum: 557832879a573e1493d12947df99d5db
+      md5sum: 03bc121a71bbb93f0da0503aee681b2a
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl

--- a/tests/workflows/test_illumina_se.yml
+++ b/tests/workflows/test_illumina_se.yml
@@ -225,7 +225,7 @@
     - path: miniwdl_run/call-primer_trim/work/_miniwdl_inputs/0/artic-v3.primers.bed
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_se/command
-      md5sum: d1bb5a2a59fe2e671e9fcb1944fce7af
+      md5sum: c0ea149681653ed6fcf15262e99fbeec
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_se/inputs.json
       contains: ["memory", "read1_trimmed", "ERR6319327"]
     - path: miniwdl_run/call-read_QC_trim/call-bbduk_se/outputs.json

--- a/tests/workflows/test_illumina_se.yml
+++ b/tests/workflows/test_illumina_se.yml
@@ -508,7 +508,7 @@
     - path: miniwdl_run/wdl/tasks/task_ncbi.wdl
       md5sum: 6ce92b1d9e2ea30352fce2be354a1086
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
-      md5sum: 03bc121a71bbb93f0da0503aee681b2a
+      md5sum: 82081b9f98af840a387e335e3dc6f5ee
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl

--- a/tests/workflows/test_ont.yml
+++ b/tests/workflows/test_ont.yml
@@ -490,7 +490,7 @@
     - path: miniwdl_run/wdl/tasks/task_ont_medaka.wdl
       md5sum: 9683dd0601393ad8d91fe3a27c311fd0
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
-      md5sum: 557832879a573e1493d12947df99d5db
+      md5sum: 03bc121a71bbb93f0da0503aee681b2a
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl

--- a/tests/workflows/test_ont.yml
+++ b/tests/workflows/test_ont.yml
@@ -490,7 +490,7 @@
     - path: miniwdl_run/wdl/tasks/task_ont_medaka.wdl
       md5sum: 9683dd0601393ad8d91fe3a27c311fd0
     - path: miniwdl_run/wdl/tasks/task_read_clean.wdl
-      md5sum: 03bc121a71bbb93f0da0503aee681b2a
+      md5sum: 82081b9f98af840a387e335e3dc6f5ee
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl

--- a/workflows/wf_pangolin_update.wdl
+++ b/workflows/wf_pangolin_update.wdl
@@ -45,7 +45,6 @@ workflow pangolin_update {
     String pangolin_update_analysis_date = version_capture.date
     # Pangolin Assignments
     String pango_lineage = pangolin4.pangolin_lineage
-    String pangolin_lineage_expanded = pangolin4.pangolin_lineage_expanded
     String pangolin_conflicts = pangolin4.pangolin_conflicts
     String pangolin_notes = pangolin4.pangolin_notes
     String pangolin_assignment_version = pangolin4.pangolin_assignment_version

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -216,11 +216,11 @@ workflow theiacov_illumina_pe {
     String assembly_fasta = select_first([consensus.consensus_seq,irma.irma_assembly_fasta,""])
     String? ivar_version_consensus = consensus.ivar_version
     String? samtools_version_consensus = consensus.samtools_version
-    Int number_N = select_first([consensus_qc.number_N,consensus_qc.number_N])
-    Int assembly_length_unambiguous =  select_first([consensus_qc.number_ATCG,consensus_qc.number_ATCG])
-    Int number_Degenerate =  select_first([consensus_qc.number_Degenerate,consensus_qc.number_Degenerate])
-    Int number_Total =  select_first([consensus_qc.number_Total,consensus_qc.number_Total])
-    Float percent_reference_coverage =  select_first([consensus_qc.percent_reference_coverage,consensus_qc.percent_reference_coverage])
+    Int number_N = consensus_qc.number_N
+    Int assembly_length_unambiguous = consensus_qc.number_ATCG
+    Int number_Degenerate =  consensus_qc.number_Degenerate
+    Int number_Total = consensus_qc.number_Total
+    Float percent_reference_coverage =  consensus_qc.percent_reference_coverage
     Int consensus_n_variant_min_depth = min_depth
     # Alignment QC
     File? consensus_stats = stats_n_coverage.stats


### PR DESCRIPTION
Ordered reads help to ensure that [downstream alignments are consistent ](https://www.biostars.org/p/238628/#238817) 