### PR TITLE
Add detection for aa substitutions associated with tamiflu-resistance

### DIFF
--- a/tasks/task_abricate_flu.wdl
+++ b/tasks/task_abricate_flu.wdl
@@ -5,9 +5,12 @@ task abricate_flu {
     File assembly
     String samplename
     String database = "insaflu"
-    String nextclade_flu_h1n1_tag
-    String nextclade_flu_h3n2_tag
-    String nextclade_flu_vic_tag
+    String nextclade_flu_h1n1_ha_tag
+    String nextclade_flu_h1n1_na_tag
+    String nextclade_flu_h3n2_ha_tag
+    String nextclade_flu_h3n2_na_tag
+    String nextclade_flu_vic_ha_tag
+    String nextclade_flu_vic_na_tag
     String nextclade_flu_yam_tag
     Int minid = 70
     Int mincov =60
@@ -34,23 +37,32 @@ task abricate_flu {
     flu_subtype="${HA_hit}${NA_hit}" && echo "$flu_subtype" >  FLU_SUBTYPE
     # set nextclade variables based on subptype
     run_nextclade=true
-    touch NEXTCLADE_REF NEXTCLADE_NAME NEXTCLADE_DS_TAG
+    touch NEXTCLADE_REF_HA NEXTCLADE_REF_NA NEXTCLADE_NAME_HA NEXTCLADE_NAME_NA NEXTCLADE_DS_TAG_HA NEXTCLADE_DS_TAG_NA
     if [ "${flu_subtype}" == "H1N1" ]; then
-      echo "flu_h1n1pdm_ha" > NEXTCLADE_NAME
-      echo "CY121680" > NEXTCLADE_REF
-      echo "~{nextclade_flu_h1n1_tag}" > NEXTCLADE_DS_TAG
+      echo "flu_h1n1pdm_ha" > NEXTCLADE_NAME_HA
+      echo "MW626062" > NEXTCLADE_REF_HA
+      echo "~{nextclade_flu_h1n1_ha_tag}" > NEXTCLADE_DS_TAG_HA
+      echo "flu_h1n1pdm_na" > NEXTCLADE_NAME_NA
+      echo "MW626056" > NEXTCLADE_REF_NA
+      echo "~{nextclade_flu_h1n1_na_tag}" > NEXTCLADE_DS_TAG_NA
     elif [ "${flu_subtype}" == "H3N2" ]; then
-      echo "flu_h3n2_ha" > NEXTCLADE_NAME
-      echo "CY163680" > NEXTCLADE_REF
-      echo "~{nextclade_flu_h3n2_tag}" > NEXTCLADE_DS_TAG
+      echo "flu_h3n2_ha" > NEXTCLADE_NAME_HA
+      echo "EPI1857216" > NEXTCLADE_REF_HA
+      echo "~{nextclade_flu_h3n2_ha_tag}" > NEXTCLADE_DS_TAG_HA
+      echo "flu_h3n2_na" > NEXTCLADE_NAME_NA
+      echo "EPI1857215" > NEXTCLADE_REF_NA
+      echo "~{nextclade_flu_h3n2_na_tag}" > NEXTCLADE_DS_TAG_NA
     elif [ "${flu_subtype}" == "Victoria" ]; then
-      echo "flu_vic_ha" > NEXTCLADE_NAME
-      echo "KX058884" > NEXTCLADE_REF
-      echo "~{nextclade_flu_vic_tag}" > NEXTCLADE_DS_TAG
+      echo "flu_vic_ha" > NEXTCLADE_NAME_HA
+      echo "KX058884" > NEXTCLADE_REF_HA
+      echo "~{nextclade_flu_vic_ha_tag}" > NEXTCLADE_DS_TAG_HA
+      echo "flu_vic_na" > NEXTCLADE_NAME_NA
+      echo "CY073894" > NEXTCLADE_REF_NA
+      echo "~{nextclade_flu_vic_na_tag}" > NEXTCLADE_DS_TAG_NA
     elif [ "${flu_subtype}" == "Yamagata" ]; then
-      echo "flu_yam_ha" > NEXTCLADE_NAME
-      echo "JN993010" > NEXTCLADE_REF
-      echo "~{nextclade_flu_yam_tag}" > NEXTCLADE_DS_TAG 
+      echo "flu_yam_ha" > NEXTCLADE_NAME_HA
+      echo "JN993010" > NEXTCLADE_REF_HA
+      echo "~{nextclade_flu_yam_tag}" > NEXTCLADE_DS_TAG_HA 
     else 
       run_nextclade=false 
     fi
@@ -63,9 +75,12 @@ task abricate_flu {
       String abricate_flu_database = database
       String abricate_flu_version = read_string("ABRICATE_VERSION")
       Boolean run_nextclade = read_boolean("RUN_NEXTCLADE")
-      String nextclade_ref = read_string("NEXTCLADE_REF")
-      String nextclade_name = read_string("NEXTCLADE_NAME")
-      String nextclade_ds_tag = read_string("NEXTCLADE_DS_TAG")
+      String nextclade_ref_ha = read_string("NEXTCLADE_REF_HA")
+      String nextclade_name_ha = read_string("NEXTCLADE_NAME_HA")
+      String nextclade_ds_tag_ha = read_string("NEXTCLADE_DS_TAG_HA")
+      String nextclade_ref_na = read_string("NEXTCLADE_REF_NA")
+      String nextclade_name_na = read_string("NEXTCLADE_NAME_NA")
+      String nextclade_ds_tag_na = read_string("NEXTCLADE_DS_TAG_NA")
 
   }
   runtime {

--- a/tasks/task_abricate_flu.wdl
+++ b/tasks/task_abricate_flu.wdl
@@ -63,6 +63,10 @@ task abricate_flu {
       echo "flu_yam_ha" > NEXTCLADE_NAME_HA
       echo "JN993010" > NEXTCLADE_REF_HA
       echo "~{nextclade_flu_yam_tag}" > NEXTCLADE_DS_TAG_HA 
+      # this makes no biological sense, but avoids errors with nextclade
+      echo "flu_vic_na" > NEXTCLADE_NAME_NA
+      echo "CY073894" > NEXTCLADE_REF_NA
+      echo "~{nextclade_flu_vic_na_tag}" > NEXTCLADE_DS_TAG_NA
     else 
       run_nextclade=false 
     fi

--- a/tasks/task_irma.wdl
+++ b/tasks/task_irma.wdl
@@ -70,8 +70,11 @@ task irma {
       mv "~{samplename}"_HA*.fasta "~{samplename}"_HA.fasta
     fi
     if compgen -G "~{samplename}_NA*.fasta" && [[ "$(ls ~{samplename}_NA*.fasta)" == *"NA_N"* ]]; then # check if NA segment exists with an N-type identified in header
-       subtype+="$(basename ~{samplename}_NA*.fasta | awk -F _ '{print $NF}' | cut -d. -f1)" # grab N-type from last value in under-score-delimited filename
+       subtype+="$(basename ~{samplename}_NA*.fasta | awk -F _ '{print $NF}' | cut -d. -f1)" # grab N-type from last value in under-score-delimited filename 
+       # format NA segment to target output name
+       mv "~{samplename}"_NA*.fasta "~{samplename}"_NA.fasta
     fi
+
     if ! [ -z "${subtype}" ]; then 
       echo "${subtype}" > IRMA_SUBTYPE
     else
@@ -80,7 +83,8 @@ task irma {
   >>>
   output {
     File? irma_assembly_fasta = "~{samplename}.irma.consensus.fasta"
-    File? seg4_ha_assembly = "~{samplename}_HA.fasta"
+    File? seg_ha_assembly = "~{samplename}_HA.fasta"
+    File? seg_na_assembly = "~{samplename}_NA.fasta"
     String irma_type = read_string("IRMA_TYPE")
     String irma_subtype = read_string("IRMA_SUBTYPE")
     Array[File] irma_assemblies = glob("~{samplename}*.fasta")

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -359,6 +359,18 @@ task nextclade_output_parser_one_sample {
       python3 <<CODE
       import csv
       import codecs
+
+      tamiflu_aa_subs = ["NA:V95A","NA:I97V","NA:E99A","NA:H101L","NA:G108E",
+      "NA:Q116L","NA:V116A","NA:E119D","NA:E119G","NA:E119I","NA:E119V","NA:R136K",
+      "NA:T146K","NA:T146P","NA:D151E","NA:N169S","NA:D179N","NA:D197N","NA:D198E",
+      "NA:D198G","NA:D198N","NA:A200T","NA:I203M","NA:I203R","NA:I203V","NA:I221T",
+      "NA:I222R","NA:I222V","NA:I223R","NA:I223V","NA:S227N","NA:S247N","NA:H255Y",
+      "NA:E258Q","NA:H274N","NA:H274Y","NA:N275S","NA:H277Y","NA:R292K","NA:N294S",
+      "NA:S334N","NA:R371K","NA:D432G","NA:H439P","NA:H439R"]
+
+      def intersection(lst1, lst2):
+        return list(set(lst1) & set(lst2))
+
       with codecs.open("./input.tsv",'r') as tsv_file:
         tsv_reader=csv.reader(tsv_file, delimiter="\t")
         tsv_data=list(tsv_reader)
@@ -389,6 +401,10 @@ task nextclade_output_parser_one_sample {
             nc_aa_subs='NA'
           else:
             nc_aa_subs=nc_aa_subs
+            if ("~{organism}" == "flu"):
+              tamiflu_subs = intersection(tamiflu_aa_subs,nc_aa_subs.split(','))
+              with codecs.open ("TAMIFLU_AASUBS", 'wt') as Tamiflu_AA_Subs:
+                Tamiflu_AA_Subs.write(",".join(tamiflu_subs))
           Nextclade_AA_Subs.write(nc_aa_subs)
         with codecs.open ("NEXTCLADE_AADELS", 'wt') as Nextclade_AA_Dels:
           nc_aa_dels=tsv_dict['aaDeletions']
@@ -416,11 +432,12 @@ task nextclade_output_parser_one_sample {
       disks:  "local-disk " + disk_size + " SSD"
       disk: disk_size + " GB" # TES
       dx_instance_type: "mem1_ssd1_v2_x2"
-      maxRetries: 3
+      maxRetries: 1
     }
     output {
       String nextclade_clade = read_string("NEXTCLADE_CLADE")
       String nextclade_aa_subs = read_string("NEXTCLADE_AASUBS")
+      String? nextclade_tamiflu_aa_subs = read_string("TAMIFLU_AASUBS")
       String nextclade_aa_dels = read_string("NEXTCLADE_AADELS")
       String nextclade_lineage = read_string("NEXTCLADE_LINEAGE")
     }

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -442,9 +442,9 @@ task nextclade_output_parser_one_sample {
       memory: "4 GB"
       cpu: 2
       disks:  "local-disk " + disk_size + " SSD"
-      disk: disk_size + " GB" # TES
+      disk: disk_size + " GB"
       dx_instance_type: "mem1_ssd1_v2_x2"
-      maxRetries: 1
+      maxRetries: 3
     }
     output {
       String nextclade_clade = read_string("NEXTCLADE_CLADE")

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -351,6 +351,7 @@ task nextclade_output_parser_one_sample {
       Int disk_size = 50
       String? organism
       Boolean? NA
+      String tamiflu_aa_substitutions = "NA:H275Y,NA:R292K"
     }
     command <<<
       # Set WDL input variable to input.tsv file
@@ -362,7 +363,8 @@ task nextclade_output_parser_one_sample {
       import csv
       import codecs
 
-      # list of aa substitutions linked with tamiflu resistance - hardcoded for now...
+      # list of aa substitutions linked with tamiflu resistance - with the possibility to
+      # extend the list with other provived aa substitutions in the format "NA:V95A,NA:I97V"
       tamiflu_aa_subs = ["NA:V95A","NA:I97V","NA:E99A","NA:H101L","NA:G108E",
       "NA:Q116L","NA:V116A","NA:E119D","NA:E119G","NA:E119I","NA:E119V","NA:R136K",
       "NA:T146K","NA:T146P","NA:D151E","NA:N169S","NA:D179N","NA:D197N","NA:D198E",
@@ -370,6 +372,10 @@ task nextclade_output_parser_one_sample {
       "NA:I222R","NA:I222V","NA:I223R","NA:I223V","NA:S227N","NA:S247N","NA:H255Y",
       "NA:E258Q","NA:H274N","NA:H274Y","NA:H275Y","NA:N275S","NA:H277Y","NA:R292K",
       "NA:N294S","NA:S334N","NA:R371K","NA:D432G","NA:H439P","NA:H439R"]
+      
+      tamiflu_aa_subs = tamiflu_aa_subs + "~{tamiflu_aa_substitutions}".split(',')
+
+      print(tamiflu_aa_subs)
 
       def intersection(lst1, lst2):
         # returns intersection between nextclade identified aa substitutions and
@@ -438,7 +444,7 @@ task nextclade_output_parser_one_sample {
       disks:  "local-disk " + disk_size + " SSD"
       disk: disk_size + " GB" # TES
       dx_instance_type: "mem1_ssd1_v2_x2"
-      maxRetries: 3
+      maxRetries: 1
     }
     output {
       String nextclade_clade = read_string("NEXTCLADE_CLADE")

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -350,10 +350,12 @@ task nextclade_output_parser_one_sample {
       String docker = "python:slim"
       Int disk_size = 50
       String? organism
+      Boolean? NA
     }
     command <<<
       # Set WDL input variable to input.tsv file
       cat "~{nextclade_tsv}" > input.tsv
+      touch TAMIFLU_AASUBS
 
       # Parse outputs using python3
       python3 <<CODE
@@ -366,8 +368,8 @@ task nextclade_output_parser_one_sample {
       "NA:T146K","NA:T146P","NA:D151E","NA:N169S","NA:D179N","NA:D197N","NA:D198E",
       "NA:D198G","NA:D198N","NA:A200T","NA:I203M","NA:I203R","NA:I203V","NA:I221T",
       "NA:I222R","NA:I222V","NA:I223R","NA:I223V","NA:S227N","NA:S247N","NA:H255Y",
-      "NA:E258Q","NA:H274N","NA:H274Y","NA:N275S","NA:H277Y","NA:R292K","NA:N294S",
-      "NA:S334N","NA:R371K","NA:D432G","NA:H439P","NA:H439R"]
+      "NA:E258Q","NA:H274N","NA:H274Y","NA:H275Y","NA:N275S","NA:H277Y","NA:R292K",
+      "NA:N294S","NA:S334N","NA:R371K","NA:D432G","NA:H439P","NA:H439R"]
 
       def intersection(lst1, lst2):
         # returns intersection between nextclade identified aa substitutions and
@@ -405,7 +407,7 @@ task nextclade_output_parser_one_sample {
           else:
             nc_aa_subs=nc_aa_subs
             # if organism is flu, return list of aa subs associated with tamiflu resistance
-            if ("~{organism}" == "flu"):
+            if ("~{organism}" == "flu" and "~{NA}" == "true"):
               tamiflu_subs = intersection(tamiflu_aa_subs,nc_aa_subs.split(','))
               with codecs.open ("TAMIFLU_AASUBS", 'wt') as Tamiflu_AA_Subs:
                 Tamiflu_AA_Subs.write(",".join(tamiflu_subs))
@@ -441,7 +443,7 @@ task nextclade_output_parser_one_sample {
     output {
       String nextclade_clade = read_string("NEXTCLADE_CLADE")
       String nextclade_aa_subs = read_string("NEXTCLADE_AASUBS")
-      String? nextclade_tamiflu_aa_subs = read_string("TAMIFLU_AASUBS")
+      String nextclade_tamiflu_aa_subs = read_string("TAMIFLU_AASUBS")
       String nextclade_aa_dels = read_string("NEXTCLADE_AADELS")
       String nextclade_lineage = read_string("NEXTCLADE_LINEAGE")
     }

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -438,7 +438,7 @@ task nextclade_output_parser_one_sample {
       disks:  "local-disk " + disk_size + " SSD"
       disk: disk_size + " GB" # TES
       dx_instance_type: "mem1_ssd1_v2_x2"
-      maxRetries: 1
+      maxRetries: 3
     }
     output {
       String nextclade_clade = read_string("NEXTCLADE_CLADE")

--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -360,6 +360,7 @@ task nextclade_output_parser_one_sample {
       import csv
       import codecs
 
+      # list of aa substitutions linked with tamiflu resistance - hardcoded for now...
       tamiflu_aa_subs = ["NA:V95A","NA:I97V","NA:E99A","NA:H101L","NA:G108E",
       "NA:Q116L","NA:V116A","NA:E119D","NA:E119G","NA:E119I","NA:E119V","NA:R136K",
       "NA:T146K","NA:T146P","NA:D151E","NA:N169S","NA:D179N","NA:D197N","NA:D198E",
@@ -369,6 +370,8 @@ task nextclade_output_parser_one_sample {
       "NA:S334N","NA:R371K","NA:D432G","NA:H439P","NA:H439R"]
 
       def intersection(lst1, lst2):
+        # returns intersection between nextclade identified aa substitutions and
+        # tamiflu associated aa substitutions
         return list(set(lst1) & set(lst2))
 
       with codecs.open("./input.tsv",'r') as tsv_file:
@@ -401,6 +404,7 @@ task nextclade_output_parser_one_sample {
             nc_aa_subs='NA'
           else:
             nc_aa_subs=nc_aa_subs
+            # if organism is flu, return list of aa subs associated with tamiflu resistance
             if ("~{organism}" == "flu"):
               tamiflu_subs = intersection(tamiflu_aa_subs,nc_aa_subs.split(','))
               with codecs.open ("TAMIFLU_AASUBS", 'wt') as Tamiflu_AA_Subs:

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -141,7 +141,7 @@ workflow theiacov_illumina_pe {
       organism = organism
     }
   }
-    if (organism == "flu" &&  defined(irma.seg_na_assembly)) { 
+    if (organism == "flu" &&  select_first([abricate_flu.run_nextclade]) && defined(irma.seg_na_assembly)) { 
     # tasks specific to flu NA - run nextclade a second time
     call taxon_ID.nextclade_one_sample as nextclade_one_sample_run2{
       input:

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -141,7 +141,7 @@ workflow theiacov_illumina_pe {
       organism = organism
     }
   }
-    if (organism == "flu" && select_first([abricate_flu.run_nextclade]) ) { 
+    if (organism == "flu" &&  defined(irma.seg_na_assembly)) { 
     # tasks specific to flu NA - run nextclade a second time
     call taxon_ID.nextclade_one_sample as nextclade_one_sample_run2{
       input:

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -141,7 +141,7 @@ workflow theiacov_illumina_pe {
       organism = organism
     }
   }
-    if (organism == "flu" && select_first([abricate_flu.run_nextclade]) && select_first([abricate_flu.abricate_flu_subtype]) != "yamagata" ) { 
+    if (organism == "flu" && select_first([abricate_flu.run_nextclade]) ) { 
     # tasks specific to flu NA - run nextclade a second time
     call taxon_ID.nextclade_one_sample as nextclade_one_sample_run2{
       input:

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -34,9 +34,12 @@ workflow theiacov_illumina_pe {
     Boolean trim_primers = true
     File? adapters
     File? phix
-    String nextclade_flu_h1n1_tag = "2022-06-08T12:00:00Z"
-    String nextclade_flu_h3n2_tag = "2022-06-08T12:00:00Z"
-    String nextclade_flu_vic_tag = "2022-06-08T12:00:00Z"
+    String nextclade_flu_h1n1_ha_tag = "2023-01-27T12:00:00Z"
+    String nextclade_flu_h1n1_na_tag = "2023-01-27T12:00:00Z"
+    String nextclade_flu_h3n2_ha_tag = "2023-02-01T12:00:00Z"
+    String nextclade_flu_h3n2_na_tag = "2023-01-27T12:00:00Z"
+    String nextclade_flu_vic_ha_tag = "2023-02-01T12:00:00Z"
+    String nextclade_flu_vic_na_tag = "2023-01-27T12:00:00Z"
     String nextclade_flu_yam_tag = "2022-07-27T12:00:00Z"
     Int? genome_length
   }
@@ -106,10 +109,13 @@ workflow theiacov_illumina_pe {
         input:
           assembly = select_first([irma.irma_assembly_fasta]),
           samplename = samplename,
-          nextclade_flu_h1n1_tag = nextclade_flu_h1n1_tag,
-          nextclade_flu_h3n2_tag = nextclade_flu_h3n2_tag,
-          nextclade_flu_vic_tag = nextclade_flu_vic_tag,
-          nextclade_flu_yam_tag = nextclade_flu_yam_tag,
+          nextclade_flu_h1n1_ha_tag = nextclade_flu_h1n1_ha_tag,
+          nextclade_flu_h1n1_na_tag = nextclade_flu_h1n1_na_tag,
+          nextclade_flu_h3n2_ha_tag = nextclade_flu_h3n2_ha_tag,
+          nextclade_flu_h3n2_na_tag = nextclade_flu_h3n2_na_tag,
+          nextclade_flu_vic_ha_tag = nextclade_flu_vic_ha_tag,
+          nextclade_flu_vic_na_tag = nextclade_flu_vic_na_tag,
+          nextclade_flu_yam_tag = nextclade_flu_yam_tag
       }
     }
   }
@@ -122,17 +128,33 @@ workflow theiacov_illumina_pe {
   # run organism-specific typing
   if (organism == "MPXV" || organism == "sars-cov-2" || organism == "flu" && select_first([abricate_flu.run_nextclade]) ) { 
     # tasks specific to either MPXV, sars-cov-2, or flu
-    call taxon_ID.nextclade_one_sample {
+    call taxon_ID.nextclade_one_sample as nextclade_one_sample_run1 {
       input:
-        genome_fasta = select_first([consensus.consensus_seq, irma.seg4_ha_assembly]),
-        dataset_name = select_first([abricate_flu.nextclade_name, nextclade_dataset_name, organism]),
-        dataset_reference = select_first([abricate_flu.nextclade_ref, nextclade_dataset_reference]),
-        dataset_tag = select_first([abricate_flu.nextclade_ds_tag, nextclade_dataset_tag])
+        genome_fasta = select_first([consensus.consensus_seq, irma.seg_ha_assembly]),
+        dataset_name = select_first([abricate_flu.nextclade_name_ha, nextclade_dataset_name, organism]),
+        dataset_reference = select_first([abricate_flu.nextclade_ref_ha, nextclade_dataset_reference]),
+        dataset_tag = select_first([abricate_flu.nextclade_ds_tag_ha, nextclade_dataset_tag])
     }
-    call taxon_ID.nextclade_output_parser_one_sample {
+    call taxon_ID.nextclade_output_parser_one_sample as nextclade_output_parser_one_sample_run1 {
       input:
-      nextclade_tsv = nextclade_one_sample.nextclade_tsv,
+      nextclade_tsv = nextclade_one_sample_run1.nextclade_tsv,
       organism = organism
+    }
+  }
+    if (organism == "flu" && select_first([abricate_flu.run_nextclade]) ) { 
+    # tasks specific to flu NA - run nextclade a second time
+    call taxon_ID.nextclade_one_sample as nextclade_one_sample_run2{
+      input:
+        genome_fasta = select_first([consensus.consensus_seq, irma.seg_na_assembly]),
+        dataset_name = select_first([abricate_flu.nextclade_name_na, nextclade_dataset_name, organism]),
+        dataset_reference = select_first([abricate_flu.nextclade_ref_na, nextclade_dataset_reference]),
+        dataset_tag = select_first([abricate_flu.nextclade_ds_tag_na, nextclade_dataset_tag])
+    }
+    call taxon_ID.nextclade_output_parser_one_sample as nextclade_output_parser_one_sample_run2 {
+      input:
+      nextclade_tsv = nextclade_one_sample_run2.nextclade_tsv,
+      organism = organism,
+      NA = true
     }
   }
   if (organism == "sars-cov-2") {
@@ -244,16 +266,19 @@ workflow theiacov_illumina_pe {
     String? pangolin_docker = pangolin4.pangolin_docker
     String? pangolin_versions = pangolin4.pangolin_versions
     # Clade Assigment
-    String nextclade_json = select_first([nextclade_one_sample.nextclade_json,""])
-    String auspice_json = select_first([ nextclade_one_sample.auspice_json,""])
-    String nextclade_tsv = select_first([nextclade_one_sample.nextclade_tsv,""])
-    String nextclade_version = select_first([nextclade_one_sample.nextclade_version,""])
-    String nextclade_docker = select_first([nextclade_one_sample.nextclade_docker,""])
-    String nextclade_ds_tag = select_first([abricate_flu.nextclade_ds_tag, nextclade_dataset_tag,""])
-    String nextclade_aa_subs = select_first([nextclade_output_parser_one_sample.nextclade_aa_subs,""])
-    String nextclade_aa_dels = select_first([nextclade_output_parser_one_sample.nextclade_aa_dels,""])
-    String nextclade_clade = select_first([nextclade_output_parser_one_sample.nextclade_clade,""])
-    String? nextclade_lineage = nextclade_output_parser_one_sample.nextclade_lineage
+    String nextclade_json = select_first([nextclade_one_sample_run1.nextclade_json,""])
+    String auspice_json = select_first([ nextclade_one_sample_run1.auspice_json,""])
+    String nextclade_tsv = select_first([nextclade_one_sample_run1.nextclade_tsv,""])
+    String nextclade_version = select_first([nextclade_one_sample_run1.nextclade_version,""])
+    String nextclade_docker = select_first([nextclade_one_sample_run1.nextclade_docker,""])
+    String nextclade_ds_tag = select_first([abricate_flu.nextclade_ds_tag_ha, nextclade_dataset_tag,""])
+    String nextclade_aa_subs = select_first([nextclade_output_parser_one_sample_run1.nextclade_aa_subs,""])
+    String? nextclade_tamiflu_aa_subs = select_first([nextclade_output_parser_one_sample_run1.nextclade_tamiflu_aa_subs,""])
+    String nextclade_aa_dels = select_first([nextclade_output_parser_one_sample_run1.nextclade_aa_dels,""])
+    String nextclade_clade = select_first([nextclade_output_parser_one_sample_run1.nextclade_clade,""])
+    String? nextclade_lineage = nextclade_output_parser_one_sample_run1.nextclade_lineage
+    # NA specific column - tamiflu mutation
+    String? tamiflu_resistance_aa_subs = nextclade_output_parser_one_sample_run2.nextclade_tamiflu_aa_subs
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -277,8 +277,10 @@ workflow theiacov_illumina_pe {
     String nextclade_aa_dels = select_first([nextclade_output_parser_one_sample_run1.nextclade_aa_dels,""])
     String nextclade_clade = select_first([nextclade_output_parser_one_sample_run1.nextclade_clade,""])
     String? nextclade_lineage = nextclade_output_parser_one_sample_run1.nextclade_lineage
-    # NA specific column - tamiflu mutation
+    # NA specific columns - tamiflu mutation
     String? tamiflu_resistance_aa_subs = nextclade_output_parser_one_sample_run2.nextclade_tamiflu_aa_subs
+    String nextclade_na_aa_subs = select_first([nextclade_output_parser_one_sample_run2.nextclade_aa_subs,""])
+    String nextclade_na_aa_dels = select_first([nextclade_output_parser_one_sample_run2.nextclade_aa_dels,""])
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -156,6 +156,10 @@ workflow theiacov_illumina_pe {
       organism = organism,
       NA = true
     }
+    # concatenate tag, aa subs and aa dels for HA and NA segments
+    String ha_na_nextclade_ds_tag= "~{abricate_flu.nextclade_ds_tag_ha + ',' + abricate_flu.nextclade_ds_tag_na}"
+    String ha_na_nextclade_aa_subs= "~{nextclade_output_parser_one_sample_run1.nextclade_aa_subs + ',' + nextclade_output_parser_one_sample_run2.nextclade_aa_subs}"
+    String ha_na_nextclade_aa_dels= "~{nextclade_output_parser_one_sample_run1.nextclade_aa_dels + ',' + nextclade_output_parser_one_sample_run2.nextclade_aa_dels}"
   }
   if (organism == "sars-cov-2") {
     # sars-cov-2 specific tasks
@@ -271,16 +275,13 @@ workflow theiacov_illumina_pe {
     String nextclade_tsv = select_first([nextclade_one_sample_run1.nextclade_tsv,""])
     String nextclade_version = select_first([nextclade_one_sample_run1.nextclade_version,""])
     String nextclade_docker = select_first([nextclade_one_sample_run1.nextclade_docker,""])
-    String nextclade_ds_tag = select_first([abricate_flu.nextclade_ds_tag_ha, nextclade_dataset_tag,""])
-    String nextclade_aa_subs = select_first([nextclade_output_parser_one_sample_run1.nextclade_aa_subs,""])
-    String? nextclade_tamiflu_aa_subs = select_first([nextclade_output_parser_one_sample_run1.nextclade_tamiflu_aa_subs,""])
-    String nextclade_aa_dels = select_first([nextclade_output_parser_one_sample_run1.nextclade_aa_dels,""])
+    String nextclade_ds_tag = select_first([ha_na_nextclade_ds_tag, abricate_flu.nextclade_ds_tag_ha, nextclade_dataset_tag,""])
+    String nextclade_aa_subs = select_first([ha_na_nextclade_aa_subs,nextclade_output_parser_one_sample_run1.nextclade_aa_subs,""])
+    String nextclade_aa_dels = select_first([ha_na_nextclade_aa_dels,nextclade_output_parser_one_sample_run1.nextclade_aa_dels,""])
     String nextclade_clade = select_first([nextclade_output_parser_one_sample_run1.nextclade_clade,""])
     String? nextclade_lineage = nextclade_output_parser_one_sample_run1.nextclade_lineage
     # NA specific columns - tamiflu mutation
-    String? tamiflu_resistance_aa_subs = nextclade_output_parser_one_sample_run2.nextclade_tamiflu_aa_subs
-    String nextclade_na_aa_subs = select_first([nextclade_output_parser_one_sample_run2.nextclade_aa_subs,""])
-    String nextclade_na_aa_dels = select_first([nextclade_output_parser_one_sample_run2.nextclade_aa_dels,""])
+    String? nextclade_tamiflu_resistance_aa_subs = nextclade_output_parser_one_sample_run2.nextclade_tamiflu_aa_subs
     # VADR Annotation QC
     File? vadr_alerts_list = vadr.alerts_list
     String? vadr_num_alerts = vadr.num_alerts

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -141,7 +141,7 @@ workflow theiacov_illumina_pe {
       organism = organism
     }
   }
-    if (organism == "flu" && select_first([abricate_flu.run_nextclade]) ) { 
+    if (organism == "flu" && select_first([abricate_flu.run_nextclade]) && select_first([abricate_flu.abricate_flu_subtype]) != "yamagata" ) { 
     # tasks specific to flu NA - run nextclade a second time
     call taxon_ID.nextclade_one_sample as nextclade_one_sample_run2{
       input:

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -145,7 +145,7 @@ workflow theiacov_illumina_pe {
     # tasks specific to flu NA - run nextclade a second time
     call taxon_ID.nextclade_one_sample as nextclade_one_sample_run2{
       input:
-        genome_fasta = select_first([consensus.consensus_seq, irma.seg_na_assembly]),
+        genome_fasta = select_first([irma.seg_na_assembly]),
         dataset_name = select_first([abricate_flu.nextclade_name_na, nextclade_dataset_name, organism]),
         dataset_reference = select_first([abricate_flu.nextclade_ref_na, nextclade_dataset_reference]),
         dataset_tag = select_first([abricate_flu.nextclade_ds_tag_na, nextclade_dataset_tag])


### PR DESCRIPTION
## Motivation

This PR adds a new column "tamiflu_resistance_aa_subs" containing nextclade-detected substitutions that have been described in the literature to confer resistance to tamiflu.

The current list of substitutions is as follows:

```bash
"NA:V95A","NA:I97V","NA:E99A","NA:H101L","NA:G108E",
"NA:Q116L","NA:V116A","NA:E119D","NA:E119G","NA:E119I","NA:E119V","NA:R136K",
"NA:T146K","NA:T146P","NA:D151E","NA:N169S","NA:D179N","NA:D197N","NA:D198E",
"NA:D198G","NA:D198N","NA:A200T","NA:I203M","NA:I203R","NA:I203V","NA:I221T",
"NA:I222R","NA:I222V","NA:I223R","NA:I223V","NA:S227N","NA:S247N","NA:H255Y",
"NA:E258Q","NA:H274N","NA:H274Y","NA:H275Y","NA:N275S","NA:H277Y","NA:R292K",
"NA:N294S","NA:S334N","NA:R371K","NA:D432G","NA:H439P","NA:H439R"
```

This is currently hard-coded into the `nextclade_output_parser_one_sample` task in the `task_taxonID.wdl` file.
The current behaviour of the workflow can be summarized in the following points:

1. when the "flu" organism is set, the read data is assembled by [IRMA](https://wonder.cdc.gov/amd/flu/irma/) which returns both the HA and NA sequence fragments.
2. [abricate](https://github.com/tseemann/abricate) returns the appropriate `nextclade_ref`, `nextclade_name` and `nextclade_ds_tag` for both HA and NA depending on the subtype detected
3. for flu, [nexclade](https://github.com/nextstrain/nextclade) runs twice, once for the HA segment and the second time for the NA segment. When running for the NA segment, it compares the detected list of aa substitutions with the list of tamiflu-resistance-associated substitutions, returning the intercept of both lists

## Testing

### Locally

`miniwdl run ~/Git/public_health_viral_genomics/workflows/wf_theiacov_illumina_pe.wdl samplename= BigTest read1_raw= ~/Test/tamiflu_resistance/SRR18273525_1.fastq.gz read2_raw= ~/Test/tamiflu_resistance/SRR18273525_2.fastq.gz organism="flu"`

### Terra

[Test 1 - Random SRA accessions](https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/899fe789-a2c3-4a3d-b1e4-c41f58dd5801)
[Test 2 - Samples 01 to 04 of theiacov flu demo dataset](https://app.terra.bio/#workspaces/theiagen-validations/Theiagen_Mendes_Sandbox/job_history/23e1743c-dc6d-4cbc-96b3-cde1550151a9)