### PR TITLE
Fix Bug RE Type-B subtyping (TheiaCoV_Illumina PE flu track)

### DIFF
--- a/tasks/task_abricate_flu.wdl
+++ b/tasks/task_abricate_flu.wdl
@@ -27,10 +27,11 @@ task abricate_flu {
       --threads ~{cpu} \
       --nopath \
       ~{assembly} > ~{samplename}_abricate_hits.tsv
-    # capturing flu type (A or B) and subtype (e.g. H1 and N1)
-    grep "M1" ~{samplename}_abricate_hits.tsv | awk -F '\t' '{ print $15 }' > FLU_TYPE
-    HA_hit=$(grep "_HA" ~{samplename}_abricate_hits.tsv | awk -F '\t' '{ print $15 }')
-    NA_hit=$(grep '_NA' ~{samplename}_abricate_hits.tsv | awk -F '\t' '{ print $15 }')
+    # capturing flu type (A or B based on M1 hit) and subtype (e.g. H1 and N1 based on HA/NA hits)
+    ## awk for gene column ($6) to grab subtype ($15)
+    awk -F '\t' '{if ($6=="M1") print $15}' > FLU_TYPE
+    HA_hit=$(awk -F '\t' '{if ($6=="HA") print $15 }')
+    NA_hit=$(awk -F '\t' '{if ($6=="NA") print $15 }')
     flu_subtype="${HA_hit}${NA_hit}" && echo "$flu_subtype" >  FLU_SUBTYPE
     # set nextclade variables based on subptype
     run_nextclade=true

--- a/tasks/task_abricate_flu.wdl
+++ b/tasks/task_abricate_flu.wdl
@@ -29,9 +29,9 @@ task abricate_flu {
       ~{assembly} > ~{samplename}_abricate_hits.tsv
     # capturing flu type (A or B based on M1 hit) and subtype (e.g. H1 and N1 based on HA/NA hits)
     ## awk for gene column ($6) to grab subtype ($15)
-    awk -F '\t' '{if ($6=="M1") print $15}' > FLU_TYPE
-    HA_hit=$(awk -F '\t' '{if ($6=="HA") print $15 }')
-    NA_hit=$(awk -F '\t' '{if ($6=="NA") print $15 }')
+    cat ~{samplename}_abricate_hits.tsv | awk -F '\t' '{if ($6=="M1") print $15}' > FLU_TYPE
+    HA_hit=$(cat ~{samplename}_abricate_hits.tsv | awk -F '\t' '{if ($6=="HA") print $15 }')
+    NA_hit=$(cat ~{samplename}_abricate_hits.tsv | awk -F '\t' '{if ($6=="NA") print $15 }')
     flu_subtype="${HA_hit}${NA_hit}" && echo "$flu_subtype" >  FLU_SUBTYPE
     # set nextclade variables based on subptype
     run_nextclade=true

--- a/tasks/task_abricate_flu.wdl
+++ b/tasks/task_abricate_flu.wdl
@@ -29,8 +29,8 @@ task abricate_flu {
       ~{assembly} > ~{samplename}_abricate_hits.tsv
     # capturing flu type (A or B) and subtype (e.g. H1 and N1)
     grep "M1" ~{samplename}_abricate_hits.tsv | awk -F '\t' '{ print $15 }' > FLU_TYPE
-    HA_hit=$(grep "HA" ~{samplename}_abricate_hits.tsv | awk -F '\t' '{ print $15 }')
-    NA_hit=$(grep 'NA' ~{samplename}_abricate_hits.tsv | awk -F '\t' '{ print $15 }')
+    HA_hit=$(grep "_HA" ~{samplename}_abricate_hits.tsv | awk -F '\t' '{ print $15 }')
+    NA_hit=$(grep '_NA' ~{samplename}_abricate_hits.tsv | awk -F '\t' '{ print $15 }')
     flu_subtype="${HA_hit}${NA_hit}" && echo "$flu_subtype" >  FLU_SUBTYPE
     # set nextclade variables based on subptype
     run_nextclade=true


### PR DESCRIPTION
This PR reinforces the text wrangling performed by the `tasks/task_abricate_flu.wdl` file to capture Type-B subtypes in the TheiaCoV_Illumina_PE workflow. 

**Issue**: Grepping for `NA` gene alone was inadvertently matching against an `RNA` string in `M1` gene hits from the Abricate output file.

**Fix**: Use awk to ensure that the string match is specific to the gene-match column of the Abricate output file.

Tests on Terra show that this fix allow for proper subtyping of both flu type b and type a: https://app.terra.bio/#workspaces/theiagen-validations/Flu_Dev/job_history/8b92137d-3161-4da9-a4c1-1dd2b7e76830