### PR TITLE
update default pangolin docker to staphb/pangolin:4.2-pdata-1.18.1.1 and nextclade_dataset_tag for SC2

### DIFF
--- a/tasks/task_taxonID.wdl
+++ b/tasks/task_taxonID.wdl
@@ -144,7 +144,7 @@ task pangolin4 {
     String samplename
     Int min_length = 10000
     Float max_ambig = 0.5
-    String docker = "staphb/pangolin:4.1.3-pdata-1.17"
+    String docker = "staphb/pangolin:4.2-pdata-1.18.1.1"
     String? analysis_mode
     Boolean expanded_lineage=true
     Boolean skip_scorpio=false

--- a/tasks/task_versioning.wdl
+++ b/tasks/task_versioning.wdl
@@ -9,7 +9,7 @@ task version_capture {
     volatile: true
   }
   command <<<
-    PHVG_Version="PHVG 2.3.0"
+    PHVG_Version="PHVG 2.3.1"
     ~{default='' 'export TZ=' + timezone}
     date +"%Y-%m-%d" > TODAY
     echo $PHVG_Version > PHVG_VERSION

--- a/tests/workflows/test_clearlabs.yml
+++ b/tests/workflows/test_clearlabs.yml
@@ -212,7 +212,7 @@
     - path: miniwdl_run/call-ncbi_scrub_se/work/r1.fastq.clean
       md5sum: 033e7bdb8c34ed0df11bf9f604addb54
     - path: miniwdl_run/call-nextclade_one_sample/command
-      md5sum: cbbe0dff285557074640df4d18205e1d
+      md5sum: 2705013ff67c2e6ecf7a9358ee52d3b7
     - path: miniwdl_run/call-nextclade_one_sample/inputs.json
       contains: ["dataset_name", "dataset_tag", "genome_fasta"]
     - path: miniwdl_run/call-nextclade_one_sample/outputs.json
@@ -314,15 +314,15 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_LINEAGE
       md5sum: 717da6cd0df2d2f1d00461f3498aaca9
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
-      md5sum: 0d654329677a43e9626ea3921b924662
+      md5sum: 3cf7fd185fe58af5952d52e91d4805c0
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 4e434d75ffecbd1669b89698d0f74d9e
+      md5sum: 983fed7641ec9e1b2d258ee1184dd75c
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: 610311d600672ebc0fb9c138cab9945a
+      md5sum: 73197f226b6f9ce6f0090d3eb41a9861
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/clearlabs.medaka.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-pangolin4/work/clearlabs.pangolin_report.csv
-      md5sum: 8f98ee098c10003b1a04cb13493aec78
+      md5sum: 45841b0ac927345415c485d363bb5f45
     - path: miniwdl_run/call-sc2_gene_coverage/command
       md5sum: 7090d929e3e59de1b4799d44824bf1d3
     - path: miniwdl_run/call-sc2_gene_coverage/inputs.json
@@ -486,11 +486,11 @@
     - path: miniwdl_run//wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl
-      md5sum: 6754daa67e78f8d2497610b9f6005ad5
+      md5sum: d7db51677d9904efb480993f64dc4410
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: 27d436979d253be67940a84696c5b77b
+      md5sum: ad14ec780a96c09a1f865773395da0f7
     - path: miniwdl_run/wdl/workflows/wf_theiacov_clearlabs.wdl
-      md5sum: 07a499e0e363f2cc339618002b98c38a
+      md5sum: aa6d9846fba576a77d270d4d536c4984
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_clearlabs", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/tests/workflows/test_illumina_pe.yml
+++ b/tests/workflows/test_illumina_pe.yml
@@ -84,7 +84,7 @@
     - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/SRR13687078.ivar.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_one_sample_run1/command
-      md5sum: 539873fddb3b5b73b99f08d0c7959943
+      md5sum: 68ed04af15a6717e9931950dab49a05d
     - path: miniwdl_run/call-nextclade_one_sample_run1/inputs.json
       contains: ["dataset_name", "genome_fasta", "SRR13687078"]
     - path: miniwdl_run/call-nextclade_one_sample_run1/outputs.json
@@ -186,13 +186,13 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_LINEAGE
       md5sum: 655588ced8f4fc5d312ed152492d6bb0
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
-      md5sum: c72695b331cf7d87edfebc08f903b081
+      md5sum: e98d2fc28664c0622f6b490433286e32
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 4e434d75ffecbd1669b89698d0f74d9e
+      md5sum: 983fed7641ec9e1b2d258ee1184dd75c
     - path: miniwdl_run/call-pangolin4/work/SRR13687078.pangolin_report.csv
-      md5sum: 47c00bf9759206ee2867357501bed615
+      md5sum: fe6a37d2d5b9c492e2a0da1a2c90231c
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: 610311d600672ebc0fb9c138cab9945a
+      md5sum: 73197f226b6f9ce6f0090d3eb41a9861
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/SRR13687078.ivar.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-primer_trim/command
@@ -602,13 +602,13 @@
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl
-      md5sum: 6754daa67e78f8d2497610b9f6005ad5
+      md5sum: d7db51677d9904efb480993f64dc4410
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: 27d436979d253be67940a84696c5b77b
+      md5sum: ad14ec780a96c09a1f865773395da0f7
     - path: miniwdl_run/wdl/workflows/wf_read_QC_trim.wdl
       md5sum: 9769f7ff548537ed7d36c5d0df445416
     - path: miniwdl_run/wdl/workflows/wf_theiacov_illumina_pe.wdl
-      md5sum: 3bdb5271010f30059416aee2ee44dbd5
+      md5sum: e12e61c3c5a9add46a04d0a0c11961e7
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_illumina_pe", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/tests/workflows/test_illumina_se.yml
+++ b/tests/workflows/test_illumina_se.yml
@@ -83,7 +83,7 @@
     - path: miniwdl_run/call-consensus_qc/work/_miniwdl_inputs/0/ERR6319327.ivar.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-nextclade_one_sample/command
-      md5sum: 00d8320c74e760d6281acf5d4764c504
+      md5sum: fd161e7657dabd1b488f1871a4b15b91
     - path: miniwdl_run/call-nextclade_one_sample/inputs.json
       contains: ["dataset_name", "genome_fasta", "ERR6319327"]
     - path: miniwdl_run/call-nextclade_one_sample/outputs.json
@@ -180,7 +180,7 @@
       contains: ["wdl", "theiacov_illumina_se", "pangolin", "done"]
     - path: miniwdl_run/call-pangolin4/work/DATE
     - path: miniwdl_run/call-pangolin4/work/ERR6319327.pangolin_report.csv
-      md5sum: 29a1f778b2387ddb31aedf2627e2c895
+      md5sum: 20ecd592059c5c10695d7c039ace61c9
     - path: miniwdl_run/call-pangolin4/work/EXPANDED_LINEAGE
       md5sum: 2430b919e9b5f418c6a13add9d3c1db8
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_CONFLICTS
@@ -188,11 +188,11 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_LINEAGE
       md5sum: 2430b919e9b5f418c6a13add9d3c1db8
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
-      md5sum: 26668c8b0624d99676391b00c9775d2a
+      md5sum: 0b1f8fb5b938fe71631f61234cbf7ab3
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 4e434d75ffecbd1669b89698d0f74d9e
+      md5sum: 983fed7641ec9e1b2d258ee1184dd75c
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: 610311d600672ebc0fb9c138cab9945a
+      md5sum: 73197f226b6f9ce6f0090d3eb41a9861
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/ERR6319327.ivar.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-primer_trim/command
@@ -512,13 +512,13 @@
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl
-      md5sum: 6754daa67e78f8d2497610b9f6005ad5
+      md5sum: d7db51677d9904efb480993f64dc4410
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: 27d436979d253be67940a84696c5b77b
+      md5sum: ad14ec780a96c09a1f865773395da0f7
     - path: miniwdl_run/wdl/workflows/wf_read_QC_trim_se.wdl
       md5sum: eb4170a3da9d95720b5403dd3d5e5d87
     - path: miniwdl_run/wdl/workflows/wf_theiacov_illumina_se.wdl
-      md5sum: 2ae893ceba2cfa4f579bb086c9ffddd9
+      md5sum: 9a21fa9bcb0c58692e4a5a5b03a0b56c
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_illumina_se", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/tests/workflows/test_ont.yml
+++ b/tests/workflows/test_ont.yml
@@ -208,7 +208,7 @@
     - path: miniwdl_run/call-ncbi_scrub_se/work/r1.fastq.clean
       md5sum: 2cf5f8defc05395fecd10c68865f9ae3
     - path: miniwdl_run/call-nextclade_one_sample/command
-      md5sum: 31d0fad6de95d8c19c087552113fe3fa
+      md5sum: 60ba5d41705947d7ada8df00dd53d0b9
     - path: miniwdl_run/call-nextclade_one_sample/inputs.json
       contains: ["dataset_name", "dataset_tag", "genome_fasta"]
     - path: miniwdl_run/call-nextclade_one_sample/outputs.json
@@ -235,7 +235,7 @@
     - path: miniwdl_run/call-nextclade_one_sample/work/nextclade_dataset_dir/primers.csv
       md5sum: 5990c3483bf66ce607aeb90a44e7ef2e
     - path: miniwdl_run/call-nextclade_one_sample/work/nextclade_dataset_dir/qc.json
-      md5sum: 518c01e982a20712d67fafb5c5fc953c
+      md5sum: 6587a54553ad565d5f8ea7d214a797d4
     - path: miniwdl_run/call-nextclade_one_sample/work/nextclade_dataset_dir/reference.fasta
       md5sum: c7ce05f28e4ec0322c96f24e064ef55c
     - path: miniwdl_run/call-nextclade_one_sample/work/nextclade_dataset_dir/sequences.fasta
@@ -313,13 +313,13 @@
     - path: miniwdl_run/call-pangolin4/work/PANGOLIN_NOTES
       md5sum: 35aa27af5fb90d54561ee9d45a3163d5
     - path: miniwdl_run/call-pangolin4/work/PANGO_ASSIGNMENT_VERSION
-      md5sum: 4e434d75ffecbd1669b89698d0f74d9e
+      md5sum: 983fed7641ec9e1b2d258ee1184dd75c
     - path: miniwdl_run/call-pangolin4/work/VERSION_PANGOLIN_ALL
-      md5sum: 610311d600672ebc0fb9c138cab9945a
+      md5sum: 73197f226b6f9ce6f0090d3eb41a9861
     - path: miniwdl_run/call-pangolin4/work/_miniwdl_inputs/0/ont.medaka.consensus.fasta
       md5sum: d41d8cd98f00b204e9800998ecf8427e
     - path: miniwdl_run/call-pangolin4/work/ont.pangolin_report.csv
-      md5sum: b7b9dcced52783d5153dc469971be4fe
+      md5sum: 65a9cb959d8749684c00bdc65626f4d8
     - path: miniwdl_run/call-read_filtering/command
       md5sum: 5a9e0fdba76808aef9f652244d355675
     - path: miniwdl_run/call-read_filtering/inputs.json
@@ -494,11 +494,11 @@
     - path: miniwdl_run/wdl/tasks/task_sc2_gene_coverage.wdl
       md5sum: e8310700d96d98cd16f4859f61dd179f
     - path: miniwdl_run/wdl/tasks/task_taxonID.wdl
-      md5sum: 6754daa67e78f8d2497610b9f6005ad5
+      md5sum: d7db51677d9904efb480993f64dc4410
     - path: miniwdl_run/wdl/tasks/task_versioning.wdl
-      md5sum: 27d436979d253be67940a84696c5b77b
+      md5sum: ad14ec780a96c09a1f865773395da0f7
     - path: miniwdl_run/wdl/workflows/wf_theiacov_ont.wdl
-      md5sum: ebee7984a3c2326d0dff24af80f57665
+      md5sum: 6a0d307ba69dd3793a1be8d512e99b54
     - path: miniwdl_run/inputs.json
       contains: ["theiacov_ont", "samplename", "primer_bed"]
     - path: miniwdl_run/outputs.json

--- a/workflows/wf_theiacov_clearlabs.wdl
+++ b/workflows/wf_theiacov_clearlabs.wdl
@@ -21,7 +21,7 @@ workflow theiacov_clearlabs {
     File primer_bed
     Int normalise = 20000
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2023-02-01T12:00:00Z"
+    String nextclade_dataset_tag = "2023-02-25T12:00:00Z"
     String medaka_docker = "quay.io/staphb/artic-ncov2019:1.3.0-medaka-1.4.3"
     String? nextclade_dataset_name
     File? reference_genome

--- a/workflows/wf_theiacov_fasta.wdl
+++ b/workflows/wf_theiacov_fasta.wdl
@@ -15,7 +15,7 @@ workflow theiacov_fasta {
     String seq_method
     String input_assembly_method
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2023-02-01T12:00:00Z"
+    String nextclade_dataset_tag = "2023-02-25T12:00:00Z"
     String? nextclade_dataset_name
     String organism = "sars-cov-2"
   }

--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -25,7 +25,7 @@ workflow theiacov_illumina_pe {
     File read2_raw
     File? primer_bed
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2023-02-01T12:00:00Z"
+    String nextclade_dataset_tag = "2023-02-25T12:00:00Z"
     String? nextclade_dataset_name
     File? reference_gff
     File? reference_genome

--- a/workflows/wf_theiacov_illumina_se.wdl
+++ b/workflows/wf_theiacov_illumina_se.wdl
@@ -21,7 +21,7 @@ workflow theiacov_illumina_se {
     File read1_raw
     File? primer_bed
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2023-02-01T12:00:00Z"
+    String nextclade_dataset_tag = "2023-02-25T12:00:00Z"
     String? nextclade_dataset_name
     File? reference_genome
     Int min_depth = 100

--- a/workflows/wf_theiacov_ont.wdl
+++ b/workflows/wf_theiacov_ont.wdl
@@ -23,7 +23,7 @@ workflow theiacov_ont {
     File demultiplexed_reads
     Int normalise = 200
     String nextclade_dataset_reference = "MN908947"
-    String nextclade_dataset_tag = "2023-02-01T12:00:00Z"
+    String nextclade_dataset_tag = "2023-02-25T12:00:00Z"
     String? nextclade_dataset_name
     File? reference_genome
     Int max_length = 700


### PR DESCRIPTION
also updated phvg to v2.3.1

new pangolin docker default: `staphb/pangolin:4.2-pdata-1.18.1.1`

new nextclade_dataset_tag default: `2023-02-25T12:00:00Z`

This PR was done right before the 2.3.1 release