### PR TITLE
Add intermediate frequency mutations screen TheiaCoV

### DIFF
--- a/workflows/wf_theiacov_illumina_pe.wdl
+++ b/workflows/wf_theiacov_illumina_pe.wdl
@@ -199,6 +199,7 @@ workflow theiacov_illumina_pe {
     String? primer_bed_name = primer_trim.primer_bed_name
     File? ivar_tsv = variant_call.sample_variants_tsv
     File? ivar_vcf = variant_call.sample_variants_vcf
+    String? ivar_variant_proportion_intermediate = variant_call.variant_proportion_intermediate
     String? ivar_variant_version = variant_call.ivar_version
     # Assembly QC
     String assembly_fasta = select_first([consensus.consensus_seq,irma.irma_assembly_fasta,""])

--- a/workflows/wf_theiacov_illumina_se.wdl
+++ b/workflows/wf_theiacov_illumina_se.wdl
@@ -160,6 +160,7 @@ workflow theiacov_illumina_se {
     String? primer_bed_name = primer_trim.primer_bed_name
     File ivar_tsv = variant_call.sample_variants_tsv
     File ivar_vcf = variant_call.sample_variants_vcf
+    String? ivar_variant_proportion_intermediate = variant_call.variant_proportion_intermediate
     String ivar_variant_version = variant_call.ivar_version
     # Assembly QC
     File assembly_fasta = consensus.consensus_seq


### PR DESCRIPTION
This PR:

- Modifies the variant_call task such that it calculated the proportion of variants at intermediate allele frequencies (60-90%). This value is reported in the output: ivar_variant_proportion_intermediate for workflows that use iVar to perform variant calling (TheiaCoV_Illumina_PE and TheiaCoV_Illumina_SE)