### PR TITLE
Add "consortium" to Mercury_Prep

### DIFF
--- a/tasks/task_mercury_file_wrangling.wdl
+++ b/tasks/task_mercury_file_wrangling.wdl
@@ -183,7 +183,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
         genbank_required = []
       
       gisaid_required = ["gisaid_submitter", "submission_id", "collection_date", "continent", "country", "state", "host", "seq_platform", assembly_fasta_column_name, "assembly_method", assembly_mean_coverage_column_name, "collecting_lab", "collecting_lab_address", "submitting_lab", "submitting_lab_address", "authors"]
-      gisaid_optional = ["gisaid_virus_name", "additional_host_information", "county", "purpose_of_sequencing", "patient_gender", "patient_age", "patient_status", "specimen_source", "outbreak", "last_vaccinated", "treatment"]
+      gisaid_optional = ["gisaid_virus_name", "additional_host_information", "county", "purpose_of_sequencing", "patient_gender", "patient_age", "patient_status", "specimen_source", "outbreak", "last_vaccinated", "treatment", "consortium"]
 
       required_metadata = biosample_required + sra_required + genbank_required + gisaid_required
 
@@ -327,7 +327,7 @@ task sm_metadata_wrangling { # the sm stands for supermassive
 
       # make dictionary for renaming headers
       # format: {original : new} or {metadata_formatter : gisaid_format}
-      gisaid_rename_headers = {"gisaid_virus_name" : "covv_virus_name", "additional_host_information" : "covv_add_host_info", "gisaid_submitter" : "submitter", "collection_date" : "covv_collection_date", "seq_platform" : "covv_seq_technology", "host" : "covv_host", "assembly_method" : "covv_assembly_method", assembly_mean_coverage_column_name : "covv_coverage", "collecting_lab" : "covv_orig_lab", "collecting_lab_address" : "covv_orig_lab_addr", "submitting_lab" : "covv_subm_lab", "submitting_lab_address" : "covv_subm_lab_addr", "authors" : "covv_authors", "purpose_of_sequencing" : "covv_sampling_strategy", "patient_gender" : "covv_gender", "patient_age" : "covv_patient_age", "patient_status" : "covv_patient_status", "specimen_source" : "covv_specimen", "outbreak" : "covv_outbreak", "last_vaccinated" : "covv_last_vaccinated", "treatment" : "covv_treatment"}
+      gisaid_rename_headers = {"gisaid_virus_name" : "covv_virus_name", "additional_host_information" : "covv_add_host_info", "gisaid_submitter" : "submitter", "collection_date" : "covv_collection_date", "seq_platform" : "covv_seq_technology", "host" : "covv_host", "assembly_method" : "covv_assembly_method", assembly_mean_coverage_column_name : "covv_coverage", "collecting_lab" : "covv_orig_lab", "collecting_lab_address" : "covv_orig_lab_addr", "submitting_lab" : "covv_subm_lab", "submitting_lab_address" : "covv_subm_lab_addr", "authors" : "covv_authors", "purpose_of_sequencing" : "covv_sampling_strategy", "patient_gender" : "covv_gender", "patient_age" : "covv_patient_age", "patient_status" : "covv_patient_status", "specimen_source" : "covv_specimen", "outbreak" : "covv_outbreak", "last_vaccinated" : "covv_last_vaccinated", "treatment" : "covv_treatment", "consortium" : "covv_consortium"}
       
       # rename columns
       gisaid_metadata.rename(columns=gisaid_rename_headers, inplace=True)

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -260,6 +260,7 @@ task gisaid_prep_one_sample {
     String? outbreak
     String? specimen_source
     String? treatment
+    String? consortium
     #runtime
     String docker = "quay.io/theiagen/utility:1.1"
     Int  memory = 1
@@ -284,11 +285,11 @@ task gisaid_prep_one_sample {
     grep -v ">" ~{assembly_fasta} >> ~{submission_id}_gisaid.fasta
     
     ##GISAID tMetadata
-    echo "submitter,fn,covv_virus_name,covv_type,covv_passage,covv_collection_date,covv_location,covv_add_location,covv_host,covv_add_host_info,covv_sampling_strategy,covv_gender,covv_patient_age,covv_patient_status,covv_specimen,covv_outbreak,covv_last_vaccinated,covv_treatment,covv_seq_technology,covv_assembly_method,covv_coverage,covv_orig_lab,covv_orig_lab_addr,covv_provider_sample_id,covv_subm_lab,covv_subm_lab_addr,covv_subm_sample_id,covv_authors,covv_comment,comment_type" >  ~{submission_id}_gisaid_metadata.csv
+    echo "submitter,fn,covv_virus_name,covv_type,covv_passage,covv_collection_date,covv_location,covv_add_location,covv_host,covv_add_host_info,covv_sampling_strategy,covv_gender,covv_patient_age,covv_patient_status,covv_specimen,covv_outbreak,covv_last_vaccinated,covv_treatment,covv_seq_technology,covv_assembly_method,covv_coverage,covv_orig_lab,covv_orig_lab_addr,covv_provider_sample_id,covv_subm_lab,covv_subm_lab_addr,covv_subm_sample_id,covv_authors,covv_comment,comment_type,covv_consortium" >  ~{submission_id}_gisaid_metadata.csv
 
-    echo "Submitter,FASTA filename,Virus name,Type,Passage details/history,Collection date,Location,Additional location information,Host,Additional host information,Sampling Strategy,Gender,Patient age,Patient status,Specimen source,Outbreak,Last vaccinated,Treatment,Sequencing technology,Assembly method,Coverage,Originating lab,Address,Sample ID given by the sample provider,Submitting lab,Address,Sample ID given by the submitting laboratory,Authors,Comment,Comment Icon" >> ~{submission_id}_gisaid_metadata.csv
+    echo "Submitter,FASTA filename,Virus name,Type,Passage details/history,Collection date,Location,Additional location information,Host,Additional host information,Sampling Strategy,Gender,Patient age,Patient status,Specimen source,Outbreak,Last vaccinated,Treatment,Sequencing technology,Assembly method,Coverage,Originating lab,Address,Sample ID given by the sample provider,Submitting lab,Address,Sample ID given by the submitting laboratory,Authors,Comment,Comment Icon,Sequencing consortium" >> ~{submission_id}_gisaid_metadata.csv
 
-    echo "\"~{gisaid_submitter}\",\"~{submission_id}.gisaid.fa\",\"~{organism}/~{country}/~{submission_id}/$year\",\"~{type}\",\"~{passage_details}\",\"~{collection_date}\",\"~{continent}/~{country}/~{state}/~{county}\",,\"~{host}\",,\"~{purpose_of_sequencing}\",\"~{patient_gender}\",\"~{patient_age}\",\"~{patient_status}\",\"~{specimen_source}\",\"~{outbreak}\",\"~{last_vaccinated}\",\"~{treatment}\",\"~{seq_platform}\",\"~{assembly_method}\",\"~{assembly_mean_coverage}\",\"~{collecting_lab}\",\"~{collecting_lab_address}\",,\"~{submitting_lab}\",\"~{submitting_lab_address}\",,\"~{authors}\",," >> ~{submission_id}_gisaid_metadata.csv
+    echo "\"~{gisaid_submitter}\",\"~{submission_id}.gisaid.fa\",\"~{organism}/~{country}/~{submission_id}/$year\",\"~{type}\",\"~{passage_details}\",\"~{collection_date}\",\"~{continent}/~{country}/~{state}/~{county}\",,\"~{host}\",,\"~{purpose_of_sequencing}\",\"~{patient_gender}\",\"~{patient_age}\",\"~{patient_status}\",\"~{specimen_source}\",\"~{outbreak}\",\"~{last_vaccinated}\",\"~{treatment}\",\"~{seq_platform}\",\"~{assembly_method}\",\"~{assembly_mean_coverage}\",\"~{collecting_lab}\",\"~{collecting_lab_address}\",,\"~{submitting_lab}\",\"~{submitting_lab_address}\",,\"~{authors}\",,,\"~{consortium}\"," >> ~{submission_id}_gisaid_metadata.csv
   >>>
   output {
     File gisaid_assembly = "~{submission_id}_gisaid.fasta"

--- a/tasks/task_versioning.wdl
+++ b/tasks/task_versioning.wdl
@@ -9,7 +9,7 @@ task version_capture {
     volatile: true
   }
   command <<<
-    PHVG_Version="PHVG 2.3.1"
+    PHVG_Version="PHVG 2.3.2"
     ~{default='' 'export TZ=' + timezone}
     date +"%Y-%m-%d" > TODAY
     echo $PHVG_Version > PHVG_VERSION

--- a/workflows/wf_mercury_pe_prep.wdl
+++ b/workflows/wf_mercury_pe_prep.wdl
@@ -53,6 +53,7 @@ workflow mercury_pe_prep {
     String? purpose_of_sequencing
     String? submitter_email
     String? treatment
+    String? consortium
     # Optional User-Defined Thresholds for Generating Submission Files
     Int number_N_threshold = 5000
   }
@@ -119,7 +120,8 @@ workflow mercury_pe_prep {
         patient_gender = patient_gender,
         patient_age = patient_age,
         purpose_of_sequencing = purpose_of_sequencing,
-        treatment = treatment
+        treatment = treatment,
+        consortium = consortium
     }
   }
   call versioning.version_capture{

--- a/workflows/wf_mercury_se_prep.wdl
+++ b/workflows/wf_mercury_se_prep.wdl
@@ -52,6 +52,7 @@ workflow mercury_se_prep {
     String? purpose_of_sequencing
     String? submitter_email
     String? treatment
+    String? consortium
     # Optional User-Defined Thresholds for Generating Submission Files
     Int number_N_threshold = 5000
   }
@@ -117,7 +118,8 @@ workflow mercury_se_prep {
         patient_gender = patient_gender,
         patient_age = patient_age,
         purpose_of_sequencing = purpose_of_sequencing,
-        treatment = treatment
+        treatment = treatment,
+        consortium = consortium
     }
   }
   call versioning.version_capture{


### PR DESCRIPTION
This PR adds the "covv_consortium" column to the output GISAID metadata file. This new optional column has been added to the metadata formatter, which can be found [here](https://console.cloud.google.com/storage/browser/theiagen-public-files/terra/mercury-files?authuser=0&project=theiagen-public-resources&supportedpurview=project) at `gs://theiagen-public-files/terra/mercury-files/Terra_Metadata_Formatter_2023_05_22.xlsx`.