### PR TITLE
Update Mercury Prep and Mercury Batch workflows to generate output compatible with GISAID's v4 command line uploader

### DIFF
--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -293,7 +293,7 @@ task gisaid_prep_one_sample {
 
     echo "submitter,virus_name,type,passage,collection_date,location,add_location,host,add_host_info,sampling_strategy,gender,patient_age,patient_status,specimen,outbreak,last_vaccinated,treatment,seq_technology,assembly_method,coverage,orig_lab,orig_lab_addr,provider_sample_id,subm_lab,subm_lab_addr,subm_sample_id,authors,comment,comment_type" >  ~{submission_id}_gisaid_covCLI_metadata.csv
 
-    echo "\"~{gisaid_submitter}\",\"~{organism}/~{country}/~{submission_id}/$year\",\"~{type}\",\"~{passage_details}\",\"~{collection_date}\",\"~{continent}/~{country}/~{state}/~{county}\",,\"~{host}\",,\"~{purpose_of_sequencing}\",\"~{patient_gender}\",\"~{patient_age}\",\"~{patient_status}\",\"~{specimen_source}\",\"~{outbreak}\",\"~{last_vaccinated}\",\"~{treatment}\",\"~{seq_platform}\",\"~{assembly_method}\",\"~{assembly_mean_coverage}\",\"~{collecting_lab}\",\"~{collecting_lab_address}\",,\"~{submitting_lab}\",\"~{submitting_lab_address}\",,\"~{authors}\",,,," >> ~{submission_id}_gisaid_covCLI_metadata.csv
+    echo "\"~{gisaid_submitter}\",\"~{organism}/~{country}/~{submission_id}/$year\",\"~{type}\",\"~{passage_details}\",\"~{collection_date}\",\"~{continent}/~{country}/~{state}/~{county}\",,\"~{host}\",,\"~{purpose_of_sequencing}\",\"~{patient_gender}\",\"~{patient_age}\",\"~{patient_status}\",\"~{specimen_source}\",\"~{outbreak}\",\"~{last_vaccinated}\",\"~{treatment}\",\"~{seq_platform}\",\"~{assembly_method}\",\"~{assembly_mean_coverage}\",\"~{collecting_lab}\",\"~{collecting_lab_address}\",,\"~{submitting_lab}\",\"~{submitting_lab_address}\",,\"~{authors}\",," >> ~{submission_id}_gisaid_covCLI_metadata.csv
     
   >>>
   output {

--- a/tasks/task_pub_repo_prep.wdl
+++ b/tasks/task_pub_repo_prep.wdl
@@ -289,11 +289,17 @@ task gisaid_prep_one_sample {
 
     echo "Submitter,FASTA filename,Virus name,Type,Passage details/history,Collection date,Location,Additional location information,Host,Additional host information,Sampling Strategy,Gender,Patient age,Patient status,Specimen source,Outbreak,Last vaccinated,Treatment,Sequencing technology,Assembly method,Coverage,Originating lab,Address,Sample ID given by the sample provider,Submitting lab,Address,Sample ID given by the submitting laboratory,Authors,Comment,Comment Icon,Sequencing consortium" >> ~{submission_id}_gisaid_metadata.csv
 
-    echo "\"~{gisaid_submitter}\",\"~{submission_id}.gisaid.fa\",\"~{organism}/~{country}/~{submission_id}/$year\",\"~{type}\",\"~{passage_details}\",\"~{collection_date}\",\"~{continent}/~{country}/~{state}/~{county}\",,\"~{host}\",,\"~{purpose_of_sequencing}\",\"~{patient_gender}\",\"~{patient_age}\",\"~{patient_status}\",\"~{specimen_source}\",\"~{outbreak}\",\"~{last_vaccinated}\",\"~{treatment}\",\"~{seq_platform}\",\"~{assembly_method}\",\"~{assembly_mean_coverage}\",\"~{collecting_lab}\",\"~{collecting_lab_address}\",,\"~{submitting_lab}\",\"~{submitting_lab_address}\",,\"~{authors}\",,,\"~{consortium}\"," >> ~{submission_id}_gisaid_metadata.csv
+    echo "\"~{gisaid_submitter}\",/\"~{submission_id}.gisaid.fa\",\"~{organism}/~{country}/~{submission_id}/$year\",\"~{type}\",\"~{passage_details}\",\"~{collection_date}\",\"~{continent}/~{country}/~{state}/~{county}\",,\"~{host}\",,\"~{purpose_of_sequencing}\",\"~{patient_gender}\",\"~{patient_age}\",\"~{patient_status}\",\"~{specimen_source}\",\"~{outbreak}\",\"~{last_vaccinated}\",\"~{treatment}\",\"~{seq_platform}\",\"~{assembly_method}\",\"~{assembly_mean_coverage}\",\"~{collecting_lab}\",\"~{collecting_lab_address}\",,\"~{submitting_lab}\",\"~{submitting_lab_address}\",,\"~{authors}\",,,\"~{consortium}\"," >> ~{submission_id}_gisaid_metadata.csv
+
+    echo "submitter,virus_name,type,passage,collection_date,location,add_location,host,add_host_info,sampling_strategy,gender,patient_age,patient_status,specimen,outbreak,last_vaccinated,treatment,seq_technology,assembly_method,coverage,orig_lab,orig_lab_addr,provider_sample_id,subm_lab,subm_lab_addr,subm_sample_id,authors,comment,comment_type" >  ~{submission_id}_gisaid_covCLI_metadata.csv
+
+    echo "\"~{gisaid_submitter}\",\"~{organism}/~{country}/~{submission_id}/$year\",\"~{type}\",\"~{passage_details}\",\"~{collection_date}\",\"~{continent}/~{country}/~{state}/~{county}\",,\"~{host}\",,\"~{purpose_of_sequencing}\",\"~{patient_gender}\",\"~{patient_age}\",\"~{patient_status}\",\"~{specimen_source}\",\"~{outbreak}\",\"~{last_vaccinated}\",\"~{treatment}\",\"~{seq_platform}\",\"~{assembly_method}\",\"~{assembly_mean_coverage}\",\"~{collecting_lab}\",\"~{collecting_lab_address}\",,\"~{submitting_lab}\",\"~{submitting_lab_address}\",,\"~{authors}\",,,," >> ~{submission_id}_gisaid_covCLI_metadata.csv
+    
   >>>
   output {
     File gisaid_assembly = "~{submission_id}_gisaid.fasta"
     File gisaid_metadata = "~{submission_id}_gisaid_metadata.csv"
+    File gisaid_covCLI_metadata = "~{submission_id}_gisaid_covCLI_metadata.csv"
   }
   runtime {
     docker: "~{docker}"

--- a/workflows/wf_mercury_batch.wdl
+++ b/workflows/wf_mercury_batch.wdl
@@ -9,6 +9,7 @@ workflow mercury_batch {
     Array[File] genbank_modifier
     Array[File] gisaid_assembly
     Array[File] gisaid_metadata
+    Array[File]? gisaid_covCLI_metadata
     Array[File] sra_metadata
     Array[String] sra_reads
     Array[File] biosample_attributes
@@ -51,6 +52,22 @@ workflow mercury_batch {
       disk_size = disk_size,
       memory = memory
   }
+
+  call submission_prep.compile_assembly_n_meta as gisaid_covCLI_compile {
+    input:
+      single_submission_fasta = gisaid_assembly,
+      single_submission_meta = gisaid_covCLI_metadata,
+      samplename = samplename,
+      vadr_num_alerts = vadr_num_alerts,
+      repository = "GISAID",
+      file_ext = "csv",
+      vadr_threshold = vadr_threshold,
+      submission_id = submission_id,
+      date = version_capture.date,
+      cpu = cpu,
+      disk_size = disk_size,
+      memory = memory
+  }
   call submission_prep.compile_biosamp_n_sra {
     input:
       single_submission_biosample_attirbutes = biosample_attributes,
@@ -76,6 +93,7 @@ workflow mercury_batch {
     File GenBank_excluded_samples = genbank_compile.excluded_samples
     # GISAID Submission Files
     File? GISAID_metadata  = gisaid_compile.upload_meta
+    File? GISAID_covCLI_metadata = gisaid_covCLI_compile.upload_meta
     File? GISAID_assembly = gisaid_compile.upload_fasta
     File GISAID_batched_samples = gisaid_compile.batched_samples
     File GISAID_excluded_samples = gisaid_compile.excluded_samples

--- a/workflows/wf_mercury_batch.wdl
+++ b/workflows/wf_mercury_batch.wdl
@@ -9,7 +9,7 @@ workflow mercury_batch {
     Array[File] genbank_modifier
     Array[File] gisaid_assembly
     Array[File] gisaid_metadata
-    Array[File]? gisaid_covCLI_metadata
+    Array[File] gisaid_covCLI_metadata
     Array[File] sra_metadata
     Array[String] sra_reads
     Array[File] biosample_attributes

--- a/workflows/wf_mercury_se_prep.wdl
+++ b/workflows/wf_mercury_se_prep.wdl
@@ -138,5 +138,6 @@ workflow mercury_se_prep {
     # GISAID Submission Files
     File? gisaid_assembly = gisaid_prep_one_sample.gisaid_assembly
     File? gisaid_metadata = gisaid_prep_one_sample.gisaid_metadata
+    File? gisaid_covCLI_metadata = gisaid_prep_one_sample.gisaid_covCLI_metadata
   }
 }


### PR DESCRIPTION
When GISAID released their new CLI package, they changed some of the column headings. Since these changes only affect CLI uploads, this modification just adds a new output "GISAID_covCLI_metadata"